### PR TITLE
feat(uiux): kill WebFetch reference fabrication (ISSUE-011)

### DIFF
--- a/docs/references/.gitkeep
+++ b/docs/references/.gitkeep
@@ -1,0 +1,3 @@
+# Image references for /uiux Reference Anchor research.
+# Populated by scripts/capture_reference.py or by manually placing image files
+# the user provides. /uiux reads these via the Read tool (image input).

--- a/docs/specs/SPEC-011.md
+++ b/docs/specs/SPEC-011.md
@@ -1,0 +1,80 @@
+# SPEC-011: Kill WebFetch reference fabrication — image-grounded references only
+
+> Linked Issue: ISSUE-011
+> Status: `accepted`
+> Date: 2026-06-14
+> Author: claude-dev-kit
+
+## Problem
+
+The `/uiux`, `/mobile-uiux`, and `/desktop-uiux` skills' Phase 2 Reference Research step instructs the model to `WebFetch` a Dribbble / Mobbin / awwwards URL and "extract concrete visual specifics: exact hex colors, font pairings, layout choice, shadow style." `WebFetch` returns parsed text — not pixels. The model is therefore being prompted to write specific values (e.g., `#1A1A1A on #F5EFE6`, `Fraunces 96/0.92`) from text descriptions, which is fabrication regardless of the `(indirect)` disclaimer downstream.
+
+## Context
+
+- The three uiux skill templates each contain the same fabrication shape ("Step 2 — Visual fetching via WebFetch (CRITICAL — do not skip)").
+- `scripts/screenshot_pilot.py` already implements headless capture (Playwright → Chrome/Chromium fallback) for pilot screens; this backend can be reused for reference URLs.
+- The Reference Anchor section is downstream input to the Decision Matrix, design philosophy, and Signature Move — fabricated hex/font values propagate into every later phase.
+- This is a correctness defect, not a quality improvement (per the reviewer who flagged it).
+
+## Options
+
+### Option A: Image-grounded only — Path (a/b/c) explicit selection
+- **Approach**: Three paths. Path (a) user-provided image URLs/paths → Read directly. Path (b) page URL → `scripts/capture_reference.py` captures to PNG → Read. Path (c) no images available → skip Reference Anchors entirely with an explicit one-line warning. Remove `WebFetch` from each skill's `allowed-tools`.
+- **Pros**:
+  - Eliminates the fabrication affordance (structural, not advisory).
+  - Reuses existing `screenshot_pilot.py` browser logic with no new dependencies.
+  - Regression-guarded by 4 tests (grep + capture script + skip path + allowed-tools).
+- **Cons**:
+  - Users without a browser backend installed lose the URL-based path (must use Path a or c).
+- **Trade-off**: +1 script (~150 LOC), +4 guard tests, -1 fabrication vector; 0 new runtime dependencies; -1 user code path for browser-less environments.
+
+### Option B: Keep WebFetch but strengthen the disclaimer
+- **Approach**: Leave the WebFetch instruction in place, replace `(indirect)` with a stronger marker (e.g., `[FABRICATED — verify]`), tell the model not to trust the extraction.
+- **Pros**:
+  - Zero code changes; zero new scripts.
+- **Cons**:
+  - Disclaimers do not change model behavior reliably; the fabrication is structural, not motivational.
+  - Downstream consumers (Signature Move, design system) still receive fabricated hex/font values.
+- **Trade-off**: -1 script vs A, 0 LOC delta; -100% correctness gain (the fabrication continues).
+
+### Option C: User must always provide images, no skip path
+- **Approach**: Hard-require image input; refuse to proceed without 1–3 image references.
+- **Pros**:
+  - Strongest grounding guarantee.
+- **Cons**:
+  - Breaks the no-reference flow (e.g., genuinely novel categories with no good reference). Phase 2 ships nothing if user can't supply images.
+  - Existing kit philosophy is "skip gracefully with explicit warning, never silently fail" — this option violates it.
+- **Trade-off**: vs A, -1 skip path; -100% novel-category coverage; +0 quality where Path (a) was already available.
+
+## Decision
+
+**Chosen: Option A.**
+
+The trade-off line "+1 script, +4 guard tests, -1 fabrication vector; 0 new runtime dependencies" wins because (i) it makes the failure mode structurally impossible by removing `WebFetch` from `allowed-tools`, (ii) it reuses the already-installed Playwright/Chromium backend, and (iii) it preserves the kit's "skip-with-explicit-warning" idiom for environments without a browser. Option B keeps the disclaimer-fix antipattern; Option C breaks valid no-reference workflows.
+
+## Trade-offs Accepted
+
+- Users in browser-less environments (cloud sandboxes, CI without Playwright) lose the URL-based path and must either install a backend or supply images directly. Documented in the skip warning.
+- Anti-reference research can still use WebSearch for *titles* of criticism articles — those are read by the model from its own knowledge of the pattern, not extracted from page text. This asymmetry is deliberate.
+- The 5-cue / 3-5 anti-cue counts are unchanged in this spec — anchor tuning is ISSUE-012's scope.
+
+## Migration
+
+1. Land `scripts/capture_reference.py` + 10 unit tests (slug derivation, CLI argument errors, no-backend exit code, success path stub).
+2. Rewrite Phase 2 step 6.5 / 7.5 in all three uiux SKILL.md.tmpl files: WebFetch instruction removed, three paths added, skip warning added.
+3. Update the Reference Anchors output spec downstream in each template to cite image paths (not generic URLs).
+4. Strengthen the Phase 2 CHECKPOINT to require either image-cited cues OR an explicit skip line.
+5. Remove `WebFetch` from `allowed-tools` in all three uiux skills (the structural guarantee).
+6. Regenerate SKILL.md files via `scripts/gen_skills.py`.
+7. Land `tests/test_uiux_reference_fabrication_guard.py` with 4 guard cases (forbidden shape regex, capture script mention, skip path mention, no WebFetch in allowed-tools).
+8. Create `docs/references/` with a `.gitkeep` explaining its purpose. No data migration needed — existing `design_philosophy.md` files keep their old anchors; they degrade quietly when this issue lands and can be re-run.
+
+## Rollback
+
+Revert the three SKILL.md.tmpl edits. Add `WebFetch` back to `allowed-tools`. Regenerate SKILL.md. Delete `scripts/capture_reference.py`, `tests/test_capture_reference.py`, `tests/test_uiux_reference_fabrication_guard.py`. `docs/references/` becomes a vestigial directory (harmless). Rollback time: < 5 minutes.
+
+## Open Questions
+
+- [ ] Should `scripts/capture_reference.py` support `--full-page` capture for long landing pages? — owner: design, by: first real Path (b) usage that requests it.
+- [ ] Should the Phase 2 CHECKPOINT have a machine-verifiable check (parse design_philosophy.md, validate every cue cites an image path)? — owner: process, by: 3 sprints from now if cue-citation regressions appear in review_notes.
+- [ ] Should anti-reference research also become image-grounded (capture criticism articles' screenshots)? — owner: design, by: when an anti-cue is observed to be fabricated.

--- a/issues.md
+++ b/issues.md
@@ -28,7 +28,6 @@
 - [ ] ISSUE-008: Virtual monorepo wrapper — polyrepo team support _(track: platform, P2, 1.5d)_
 - [ ] ISSUE-009: Install script --pack flag + merge_settings + tests _(track: platform, P1, 1.5d)_
 - [ ] ISSUE-010: Pilot Gate hardening — separate-context critic + auto-cycle + neutral observation + specificity check _(track: platform, P2, 1.5d)_
-- [ ] ISSUE-011: Kill WebFetch reference fabrication — image-grounded references only _(track: platform, P1, 0.5d)_
 - [ ] ISSUE-012: Reference Anchor tuning — 2-3 strong cues + 1 literal quote _(track: platform, P2, 0.5d)_
 - [ ] ISSUE-013: Consolidate ui-reviewer / design-auditor agents — sharpen role boundaries _(track: platform, P2, 1d)_
 
@@ -39,6 +38,7 @@
 ### Done
 - [x] ISSUE-006: /spec skill — RFC pattern + Spec-Required metadata + non-sprint HOLD gate _(track: platform, P1, 1.5d)_
 - [x] ISSUE-007: /implement spec gate — sprint auto-run + non-sprint HOLD + signal detection _(track: platform, P1, 1d)_
+- [x] ISSUE-011: Kill WebFetch reference fabrication — image-grounded references only _(track: platform, P1, 0.5d)_
 
 ### Drop
 
@@ -668,10 +668,12 @@ Revert Phase 5A changes in `skills/uiux/SKILL.md` (+ mobile/desktop). Step 2 rev
 - UI: false
 - Platform: web
 - Manual: false
+- Spec-Required: true
+- Spec: docs/specs/SPEC-011.md
 - PRD-Ref: none (kit self-development; rationale in conversation 2026-06-13 — WebFetch returns parsed text only; asking the model to extract hex values "from a Dribbble URL" via WebFetch is fabrication regardless of the "(indirect)" label)
 - Priority: P1
 - Estimate: 0.5d
-- Status: backlog
+- Status: done
 - Owner:
 - Branch:
 - GH-Issue:

--- a/scripts/capture_reference.py
+++ b/scripts/capture_reference.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Capture a reference page URL to PNG for image-grounded /uiux input.
+
+ISSUE-011: Phase 2 step 6.5 of the uiux skill no longer uses WebFetch to
+"read" visual references — WebFetch returns parsed text, which means extracted
+"hex colors" and "font pairings" were fabrications. References must arrive as
+actual pixels.
+
+Two paths:
+- user-provided image URL / local path → /uiux Reads the image directly
+- HTML page URL → this script captures it to PNG via headless browser
+
+Uses the same backend probing logic as screenshot_pilot.py (Playwright → headless
+Chrome/Chromium). Saves under docs/references/ by default.
+
+Exit codes:
+    0 = success, PNG written
+    2 = bad input (URL missing, etc.)
+    3 = no screenshot backend available
+
+Usage:
+    python3 scripts/capture_reference.py https://linear.app/
+    python3 scripts/capture_reference.py https://linear.app/ --out docs/references/linear.png
+    python3 scripts/capture_reference.py https://linear.app/ --slug linear-landing
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+DEFAULT_DIR = Path("docs/references")
+DEFAULT_VIEWPORT = (1440, 900)
+
+
+def slug_from_url(url: str) -> str:
+    """Derive a filesystem-safe slug from a URL."""
+    parsed = urlparse(url)
+    base = parsed.netloc.replace(".", "-") or "ref"
+    path = re.sub(r"[^a-zA-Z0-9]+", "-", parsed.path).strip("-")
+    if path:
+        base = f"{base}-{path}"
+    return base[:80].strip("-") or "ref"
+
+
+def try_playwright(url: str, out: Path, viewport: tuple[int, int]) -> bool:
+    try:
+        from playwright.sync_api import sync_playwright  # type: ignore
+    except ImportError:
+        return False
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        try:
+            page = browser.new_page(
+                viewport={"width": viewport[0], "height": viewport[1]}
+            )
+            page.goto(url, wait_until="networkidle", timeout=30_000)
+            page.wait_for_timeout(800)
+            page.screenshot(path=str(out), full_page=False)
+        finally:
+            browser.close()
+    return out.exists()
+
+
+def try_chrome(url: str, out: Path, viewport: tuple[int, int]) -> bool:
+    candidates = [
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    ]
+    for binary in candidates:
+        path = shutil.which(binary) or (binary if Path(binary).exists() else None)
+        if not path:
+            continue
+        try:
+            subprocess.run(
+                [
+                    path,
+                    "--headless=new",
+                    f"--screenshot={out}",
+                    f"--window-size={viewport[0]},{viewport[1]}",
+                    "--hide-scrollbars",
+                    "--no-sandbox",
+                    url,
+                ],
+                check=True,
+                capture_output=True,
+                timeout=60,
+            )
+            if out.exists():
+                return True
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            continue
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Capture reference page to PNG")
+    ap.add_argument("url", help="Page URL to capture")
+    ap.add_argument(
+        "--out",
+        type=Path,
+        help=f"Output PNG path (default: {DEFAULT_DIR}/<slug>.png)",
+    )
+    ap.add_argument(
+        "--slug",
+        help="Filename slug (default: derived from URL host+path)",
+    )
+    ap.add_argument(
+        "--viewport",
+        default=f"{DEFAULT_VIEWPORT[0]}x{DEFAULT_VIEWPORT[1]}",
+        help=f"Viewport WxH (default: {DEFAULT_VIEWPORT[0]}x{DEFAULT_VIEWPORT[1]})",
+    )
+    args = ap.parse_args(argv)
+
+    if not args.url.startswith(("http://", "https://")):
+        print(
+            f"error: URL must start with http:// or https://, got {args.url!r}",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.out:
+        out = args.out
+    else:
+        slug = args.slug or slug_from_url(args.url)
+        out = DEFAULT_DIR / f"{slug}.png"
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        w, h = args.viewport.lower().split("x")
+        viewport = (int(w), int(h))
+    except ValueError:
+        print(f"error: bad --viewport {args.viewport!r}", file=sys.stderr)
+        return 2
+
+    if try_playwright(args.url, out, viewport):
+        print(f"reference: {out} (playwright)")
+        return 0
+    if try_chrome(args.url, out, viewport):
+        print(f"reference: {out} (headless chrome)")
+        return 0
+
+    print(
+        "no screenshot backend available — cannot capture a reference page.\n"
+        "Either install one of:\n"
+        "  - playwright:  uv add --dev playwright && uv run playwright install chromium\n"
+        "  - Google Chrome (macOS/Linux/Windows)\n"
+        "  - chromium-browser (Linux)\n"
+        "\n"
+        "Or pass image paths directly to /uiux (image URLs or local files) so it\n"
+        "can Read them as pixels without a browser.",
+        file=sys.stderr,
+    )
+    return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/desktop-uiux/SKILL.md
+++ b/skills/desktop-uiux/SKILL.md
@@ -4,7 +4,7 @@ name: desktop-uiux
 description: Establishes a desktop design philosophy based on kickoff outputs, and generates a desktop design system/wireframes/Electron prototype. Recommended flow: /prd → /kickoff → /desktop-uiux
 argument-hint: [PRD.md path (optional)]
 disable-model-invocation: false
-allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
+allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
 ---
 
 ## Kit Preamble — desktop-uiux
@@ -125,19 +125,38 @@ If the result is `true`:
    - Who are the users? What's the emotional tone?
    - What category does this product belong to?
    - Are there competitor/reference apps mentioned?
-7.5) **Reference Research** (uses WebSearch + WebFetch):
-   - Step 1 — Source discovery via WebSearch (restrict to visual showcase sites):
-     - Aspiration reference: `"[brand/product] desktop UI site:dribbble.com OR site:behance.net OR site:awwwards.com OR site:land-book.com"`
-     - Anti-reference: `"[anti-reference] UI criticism"`
-     - Domain trends: `"[domain] desktop app design 2025 2026 showcase"`
-   - Step 2 — Visual fetching via WebFetch (CRITICAL — do not skip):
-     - From search results, pick 2–3 URLs that point to actual visual showcases (case studies, product hero pages, brand press kits) — NOT text-only articles.
-     - WebFetch each URL. Extract concrete visual specifics: exact hex colors, font choices and sizes, sidebar/split-pane proportions, title-bar treatment, command-palette style, density (compact vs roomy), dark-mode strategy.
-     - If WebFetch returns text-only without resolvable visuals, fall back to careful synthesis but mark the cue as `(indirect)`.
-   - Step 3 — Synthesis (output goes into `docs/design_philosophy.md` "Reference Anchors"):
-     - **5 specific visual cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `sidebar 240px @ #0E0F12`, `JetBrains Mono 13 + Inter 13`, `title bar 28px frameless with traffic lights inset 12/12`) — source URL.
-     - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
-     - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a generic Electron/Material default. Prose-only cues are rejected.
+7.5) **Reference Research — image-grounded only** (NO WebFetch for visual extraction).
+
+   WebFetch returns parsed text, not pixels. Asking the model to extract hex values or sidebar proportions from a Dribbble URL via WebFetch is fabrication. Visual references MUST arrive as actual images.
+
+   Pick exactly ONE of three paths:
+
+   - **Path (a) — user-provided images** (preferred):
+     - The user supplies 1–3 desktop screenshots / app hero shots (image URLs or local file paths).
+     - Read each image with the Read tool (image input).
+     - For each image, extract concrete cues from what you actually see: dominant hex (`≈#…`), sidebar/split-pane proportions, title bar treatment, command palette presence, density (compact / roomy), dark-mode handling.
+
+   - **Path (b) — page URLs**:
+     - For each reference page URL, run:
+       ```bash
+       python3 scripts/capture_reference.py <url> --viewport 1440x900
+       ```
+       This headless-captures the page into `docs/references/<slug>.png`. If the script exits non-zero, STOP this path and switch to Path (a) or Path (c).
+     - Read every captured PNG.
+     - Extract cues grounded in the actual capture.
+
+   - **Path (c) — no images available**:
+     - Skip the Reference Anchors section entirely. Print this one-line warning to the user:
+       `Reference Anchor skipped: no image provided. Pass 1–3 desktop screenshot paths or a page URL (with Playwright/Chrome installed) to populate this section.`
+     - Proceed to step 8 (aesthetic direction) WITHOUT a Reference Anchors section. The Signature Move + Decision Matrix still anchor the design.
+
+   **Anti-reference**: WebSearch for *anti-reference titles* is acceptable. Anti-cues are written from the model's own knowledge.
+
+   **Synthesis** (when Path (a) or (b) ran — output goes into `docs/design_philosophy.md` "Reference Anchors"):
+   - **5 specific visual cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `sidebar 240px @ #0E0F12`, `JetBrains Mono 13 + Inter 13`, `title bar 28px frameless with traffic lights inset 12/12`) — **source image path under `docs/references/` OR user-provided image URL/path**.
+   - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
+   - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a generic Electron/Material default. Prose-only cues are rejected.
+   - Never invent hex / font / sizing values without an image to point at. Mark uncertain extractions with `≈` and cite the source image.
 8) Commit to a BOLD aesthetic direction with desktop lens:
    - Apply the desktop design lens: information density, keyboard workflow, multi-window experience
 9) Generate `docs/design_philosophy.md`:
@@ -154,14 +173,14 @@ If the result is `true`:
        - "Command palette: `clip-path: polygon(...)` notched bottom-right corner, 480×320 fixed — never plain rounded rectangle"
        - "Sidebar split: `grid-template-columns: 240px 1fr` with a 1px hairline divider in `--border-strong`, no shadow"
        - "Title bar: 28px frameless with traffic lights inset 12/12, app icon at 16px — never default window chrome"
-   - **Reference Anchors** section (from step 7.5 visual research): 5 adopted cues with source URLs, 3–5 avoided cues with reasons.
+   - **Reference Anchors** section (from step 7.5 image-grounded research): 5 adopted cues each citing an image (path under `docs/references/` or a user-provided image URL/path), 3–5 avoided cues with reasons. If step 7.5 took Path (c) and skipped this section, omit it here too and proceed.
    - What makes this design UNFORGETTABLE (should align with and reinforce the Signature Move).
 10) Present the design philosophy to the user and ask for approval before proceeding.
     - If rejected, iterate on the direction.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
-> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) **Reference Anchors** with 5 adopted cues each carrying a source URL.
-> If the Signature Move is prose-only, or Reference Anchors lack source URLs: STOP and fix before proceeding.
+> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line. If Reference Anchors is present, every adopted cue MUST cite an image path under `docs/references/` or a user-provided image URL/path — NOT a generic webpage URL that was WebFetched.
+> If the Signature Move is prose-only, or Reference Anchors lacks image citations, or Reference Anchors has 0 cues without an explicit skip line: STOP and fix before proceeding.
 
 ### Phase 3 — Desktop Design System
 11) Generate `docs/design_system_desktop.md` reflecting the chosen aesthetic:

--- a/skills/desktop-uiux/SKILL.md.tmpl
+++ b/skills/desktop-uiux/SKILL.md.tmpl
@@ -3,7 +3,7 @@ name: desktop-uiux
 description: Establishes a desktop design philosophy based on kickoff outputs, and generates a desktop design system/wireframes/Electron prototype. Recommended flow: /prd → /kickoff → /desktop-uiux
 argument-hint: [PRD.md path (optional)]
 disable-model-invocation: false
-allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
+allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
 ---
 
 {{PREAMBLE}}
@@ -89,19 +89,38 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
    - Who are the users? What's the emotional tone?
    - What category does this product belong to?
    - Are there competitor/reference apps mentioned?
-7.5) **Reference Research** (uses WebSearch + WebFetch):
-   - Step 1 — Source discovery via WebSearch (restrict to visual showcase sites):
-     - Aspiration reference: `"[brand/product] desktop UI site:dribbble.com OR site:behance.net OR site:awwwards.com OR site:land-book.com"`
-     - Anti-reference: `"[anti-reference] UI criticism"`
-     - Domain trends: `"[domain] desktop app design 2025 2026 showcase"`
-   - Step 2 — Visual fetching via WebFetch (CRITICAL — do not skip):
-     - From search results, pick 2–3 URLs that point to actual visual showcases (case studies, product hero pages, brand press kits) — NOT text-only articles.
-     - WebFetch each URL. Extract concrete visual specifics: exact hex colors, font choices and sizes, sidebar/split-pane proportions, title-bar treatment, command-palette style, density (compact vs roomy), dark-mode strategy.
-     - If WebFetch returns text-only without resolvable visuals, fall back to careful synthesis but mark the cue as `(indirect)`.
-   - Step 3 — Synthesis (output goes into `docs/design_philosophy.md` "Reference Anchors"):
-     - **5 specific visual cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `sidebar 240px @ #0E0F12`, `JetBrains Mono 13 + Inter 13`, `title bar 28px frameless with traffic lights inset 12/12`) — source URL.
-     - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
-     - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a generic Electron/Material default. Prose-only cues are rejected.
+7.5) **Reference Research — image-grounded only** (NO WebFetch for visual extraction).
+
+   WebFetch returns parsed text, not pixels. Asking the model to extract hex values or sidebar proportions from a Dribbble URL via WebFetch is fabrication. Visual references MUST arrive as actual images.
+
+   Pick exactly ONE of three paths:
+
+   - **Path (a) — user-provided images** (preferred):
+     - The user supplies 1–3 desktop screenshots / app hero shots (image URLs or local file paths).
+     - Read each image with the Read tool (image input).
+     - For each image, extract concrete cues from what you actually see: dominant hex (`≈#…`), sidebar/split-pane proportions, title bar treatment, command palette presence, density (compact / roomy), dark-mode handling.
+
+   - **Path (b) — page URLs**:
+     - For each reference page URL, run:
+       ```bash
+       python3 scripts/capture_reference.py <url> --viewport 1440x900
+       ```
+       This headless-captures the page into `docs/references/<slug>.png`. If the script exits non-zero, STOP this path and switch to Path (a) or Path (c).
+     - Read every captured PNG.
+     - Extract cues grounded in the actual capture.
+
+   - **Path (c) — no images available**:
+     - Skip the Reference Anchors section entirely. Print this one-line warning to the user:
+       `Reference Anchor skipped: no image provided. Pass 1–3 desktop screenshot paths or a page URL (with Playwright/Chrome installed) to populate this section.`
+     - Proceed to step 8 (aesthetic direction) WITHOUT a Reference Anchors section. The Signature Move + Decision Matrix still anchor the design.
+
+   **Anti-reference**: WebSearch for *anti-reference titles* is acceptable. Anti-cues are written from the model's own knowledge.
+
+   **Synthesis** (when Path (a) or (b) ran — output goes into `docs/design_philosophy.md` "Reference Anchors"):
+   - **5 specific visual cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `sidebar 240px @ #0E0F12`, `JetBrains Mono 13 + Inter 13`, `title bar 28px frameless with traffic lights inset 12/12`) — **source image path under `docs/references/` OR user-provided image URL/path**.
+   - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
+   - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a generic Electron/Material default. Prose-only cues are rejected.
+   - Never invent hex / font / sizing values without an image to point at. Mark uncertain extractions with `≈` and cite the source image.
 8) Commit to a BOLD aesthetic direction with desktop lens:
    - Apply the desktop design lens: information density, keyboard workflow, multi-window experience
 9) Generate `docs/design_philosophy.md`:
@@ -118,14 +137,14 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
        - "Command palette: `clip-path: polygon(...)` notched bottom-right corner, 480×320 fixed — never plain rounded rectangle"
        - "Sidebar split: `grid-template-columns: 240px 1fr` with a 1px hairline divider in `--border-strong`, no shadow"
        - "Title bar: 28px frameless with traffic lights inset 12/12, app icon at 16px — never default window chrome"
-   - **Reference Anchors** section (from step 7.5 visual research): 5 adopted cues with source URLs, 3–5 avoided cues with reasons.
+   - **Reference Anchors** section (from step 7.5 image-grounded research): 5 adopted cues each citing an image (path under `docs/references/` or a user-provided image URL/path), 3–5 avoided cues with reasons. If step 7.5 took Path (c) and skipped this section, omit it here too and proceed.
    - What makes this design UNFORGETTABLE (should align with and reinforce the Signature Move).
 10) Present the design philosophy to the user and ask for approval before proceeding.
     - If rejected, iterate on the direction.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
-> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) **Reference Anchors** with 5 adopted cues each carrying a source URL.
-> If the Signature Move is prose-only, or Reference Anchors lack source URLs: STOP and fix before proceeding.
+> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line. If Reference Anchors is present, every adopted cue MUST cite an image path under `docs/references/` or a user-provided image URL/path — NOT a generic webpage URL that was WebFetched.
+> If the Signature Move is prose-only, or Reference Anchors lacks image citations, or Reference Anchors has 0 cues without an explicit skip line: STOP and fix before proceeding.
 
 ### Phase 3 — Desktop Design System
 11) Generate `docs/design_system_desktop.md` reflecting the chosen aesthetic:

--- a/skills/mobile-uiux/SKILL.md
+++ b/skills/mobile-uiux/SKILL.md
@@ -4,7 +4,7 @@ name: mobile-uiux
 description: Establishes a mobile design philosophy based on kickoff outputs, and generates a mobile design system/wireframes/React Native (Expo) prototype. Recommended flow: /prd → /kickoff → /mobile-uiux
 argument-hint: [PRD.md path (optional)]
 disable-model-invocation: false
-allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
+allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
 ---
 
 ## Kit Preamble — mobile-uiux
@@ -121,19 +121,38 @@ If the result is `true`:
    - Who are the users? What's the emotional tone?
    - What category does this product belong to?
    - Are there competitor/reference apps mentioned?
-7.5) **Reference Research** (uses WebSearch + WebFetch):
-   - Step 1 — Source discovery via WebSearch (restrict to visual showcase sites):
-     - Aspiration reference: `"[brand/product] mobile UI site:mobbin.com OR site:dribbble.com OR site:behance.net OR site:awwwards.com"`
-     - Anti-reference: `"[anti-reference] UI criticism"`
-     - Domain trends: `"[domain] mobile app design 2025 2026 showcase"`
-   - Step 2 — Visual fetching via WebFetch (CRITICAL — do not skip):
-     - From search results, pick 2–3 URLs that point to actual visual showcases (Mobbin flows, app store screenshots, brand press kits) — NOT text-only articles.
-     - WebFetch each URL. Extract concrete visual specifics: exact hex colors, font choices and sizes, spring/easing feel, gesture and haptic patterns, tab bar treatment, screen-transition style, dark mode strategy.
-     - If WebFetch returns text-only without resolvable visuals, fall back to careful synthesis but mark the cue as `(indirect)`.
-   - Step 3 — Synthesis (output goes into `docs/design_philosophy.md` "Reference Anchors"):
-     - **5 specific visual cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `OLED black #000 + #0A0A0A surface`, `SF Pro Display 34/40 + SF Mono 13`, `spring damping=18 stiffness=180`) — source URL.
-     - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
-     - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a Material/HIG default. Prose-only cues are rejected.
+7.5) **Reference Research — image-grounded only** (NO WebFetch for visual extraction).
+
+   WebFetch returns parsed text, not pixels. Asking the model to extract hex values or spring constants from a Mobbin URL via WebFetch is fabrication. Visual references MUST arrive as actual images.
+
+   Pick exactly ONE of three paths:
+
+   - **Path (a) — user-provided images** (preferred):
+     - The user supplies 1–3 mobile screenshots / hero shots (image URLs ending in `.png`/`.jpg`/`.webp` OR local file paths). App-store screenshots are ideal.
+     - Read each image with the Read tool (image input).
+     - For each image, extract concrete cues from what you actually see: dominant hex guesses (`≈#…`), font category (SF/Roboto/grotesque/serif/mono with weight), spacing/grid, tab bar / nav treatment, dark-mode strategy, presence of glass/blur/elevation. **Spring/haptic constants cannot be extracted from a static image** — leave those to the Signature Move, not the Reference Anchors.
+
+   - **Path (b) — page URLs**:
+     - For each reference page URL, run:
+       ```bash
+       python3 scripts/capture_reference.py <url> --viewport 390x844
+       ```
+       This headless-captures the page at a mobile viewport into `docs/references/<slug>.png`. If the script exits non-zero, STOP this path and switch to Path (a) or Path (c).
+     - Read every captured PNG.
+     - Extract cues grounded in the actual capture.
+
+   - **Path (c) — no images available**:
+     - Skip the Reference Anchors section entirely. Print this one-line warning to the user:
+       `Reference Anchor skipped: no image provided. Pass 1–3 mobile screenshot paths or a page URL (with Playwright/Chrome installed) to populate this section.`
+     - Proceed to step 8 (aesthetic direction) WITHOUT a Reference Anchors section. The Signature Move + Decision Matrix still anchor the design.
+
+   **Anti-reference**: WebSearch for *anti-reference titles* is acceptable. Anti-cues are written from the model's own knowledge of patterns being avoided.
+
+   **Synthesis** (when Path (a) or (b) ran — output goes into `docs/design_philosophy.md` "Reference Anchors"):
+   - **5 specific visual cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `OLED black #000 + #0A0A0A surface`, `SF Pro Display 34/40 + SF Mono 13`) — **source image path under `docs/references/` OR user-provided image URL/path**.
+   - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
+   - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a Material/HIG default. Prose-only cues are rejected.
+   - Never invent hex / font / spacing values without an image to point at. Mark uncertain extractions with `≈` and cite the source image.
 8) Commit to a BOLD aesthetic direction with mobile lens:
    - Apply the mobile design lens: one-handed usability, first 3-second impression, memorable gestures
 9) Generate `docs/design_philosophy.md`:
@@ -150,14 +169,14 @@ If the result is `true`:
        - "List items use `borderLeftWidth: 4` in `colors.accent` on the focused/active row only — no background highlight"
        - "FABs offset 16pt above the home indicator and overhang the safe area by -12pt — never centered"
        - "Bottom sheet snap points: 35% / 70% / 100% with `swipeDownEnabled` + Haptic.Light on snap"
-   - **Reference Anchors** section (from step 7.5 visual research): 5 adopted cues with source URLs, 3–5 avoided cues with reasons.
+   - **Reference Anchors** section (from step 7.5 image-grounded research): 5 adopted cues each citing an image (path under `docs/references/` or a user-provided image URL/path), 3–5 avoided cues with reasons. If step 7.5 took Path (c) and skipped this section, omit it here too and proceed.
    - What makes this design UNFORGETTABLE (should align with and reinforce the Signature Move).
 10) Present the design philosophy to the user and ask for approval before proceeding.
     - If rejected, iterate on the direction.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
-> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) **Reference Anchors** with 5 adopted cues each carrying a source URL.
-> If the Signature Move is prose-only, or Reference Anchors lack source URLs: STOP and fix before proceeding.
+> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line. If Reference Anchors is present, every adopted cue MUST cite an image path under `docs/references/` or a user-provided image URL/path — NOT a generic webpage URL that was WebFetched.
+> If the Signature Move is prose-only, or Reference Anchors lacks image citations, or Reference Anchors has 0 cues without an explicit skip line: STOP and fix before proceeding.
 
 ### Phase 3 — Mobile Design System
 11) Generate `docs/design_system_mobile.md` reflecting the chosen aesthetic:

--- a/skills/mobile-uiux/SKILL.md.tmpl
+++ b/skills/mobile-uiux/SKILL.md.tmpl
@@ -3,7 +3,7 @@ name: mobile-uiux
 description: Establishes a mobile design philosophy based on kickoff outputs, and generates a mobile design system/wireframes/React Native (Expo) prototype. Recommended flow: /prd → /kickoff → /mobile-uiux
 argument-hint: [PRD.md path (optional)]
 disable-model-invocation: false
-allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
+allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
 ---
 
 {{PREAMBLE}}
@@ -85,19 +85,38 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
    - Who are the users? What's the emotional tone?
    - What category does this product belong to?
    - Are there competitor/reference apps mentioned?
-7.5) **Reference Research** (uses WebSearch + WebFetch):
-   - Step 1 — Source discovery via WebSearch (restrict to visual showcase sites):
-     - Aspiration reference: `"[brand/product] mobile UI site:mobbin.com OR site:dribbble.com OR site:behance.net OR site:awwwards.com"`
-     - Anti-reference: `"[anti-reference] UI criticism"`
-     - Domain trends: `"[domain] mobile app design 2025 2026 showcase"`
-   - Step 2 — Visual fetching via WebFetch (CRITICAL — do not skip):
-     - From search results, pick 2–3 URLs that point to actual visual showcases (Mobbin flows, app store screenshots, brand press kits) — NOT text-only articles.
-     - WebFetch each URL. Extract concrete visual specifics: exact hex colors, font choices and sizes, spring/easing feel, gesture and haptic patterns, tab bar treatment, screen-transition style, dark mode strategy.
-     - If WebFetch returns text-only without resolvable visuals, fall back to careful synthesis but mark the cue as `(indirect)`.
-   - Step 3 — Synthesis (output goes into `docs/design_philosophy.md` "Reference Anchors"):
-     - **5 specific visual cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `OLED black #000 + #0A0A0A surface`, `SF Pro Display 34/40 + SF Mono 13`, `spring damping=18 stiffness=180`) — source URL.
-     - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
-     - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a Material/HIG default. Prose-only cues are rejected.
+7.5) **Reference Research — image-grounded only** (NO WebFetch for visual extraction).
+
+   WebFetch returns parsed text, not pixels. Asking the model to extract hex values or spring constants from a Mobbin URL via WebFetch is fabrication. Visual references MUST arrive as actual images.
+
+   Pick exactly ONE of three paths:
+
+   - **Path (a) — user-provided images** (preferred):
+     - The user supplies 1–3 mobile screenshots / hero shots (image URLs ending in `.png`/`.jpg`/`.webp` OR local file paths). App-store screenshots are ideal.
+     - Read each image with the Read tool (image input).
+     - For each image, extract concrete cues from what you actually see: dominant hex guesses (`≈#…`), font category (SF/Roboto/grotesque/serif/mono with weight), spacing/grid, tab bar / nav treatment, dark-mode strategy, presence of glass/blur/elevation. **Spring/haptic constants cannot be extracted from a static image** — leave those to the Signature Move, not the Reference Anchors.
+
+   - **Path (b) — page URLs**:
+     - For each reference page URL, run:
+       ```bash
+       python3 scripts/capture_reference.py <url> --viewport 390x844
+       ```
+       This headless-captures the page at a mobile viewport into `docs/references/<slug>.png`. If the script exits non-zero, STOP this path and switch to Path (a) or Path (c).
+     - Read every captured PNG.
+     - Extract cues grounded in the actual capture.
+
+   - **Path (c) — no images available**:
+     - Skip the Reference Anchors section entirely. Print this one-line warning to the user:
+       `Reference Anchor skipped: no image provided. Pass 1–3 mobile screenshot paths or a page URL (with Playwright/Chrome installed) to populate this section.`
+     - Proceed to step 8 (aesthetic direction) WITHOUT a Reference Anchors section. The Signature Move + Decision Matrix still anchor the design.
+
+   **Anti-reference**: WebSearch for *anti-reference titles* is acceptable. Anti-cues are written from the model's own knowledge of patterns being avoided.
+
+   **Synthesis** (when Path (a) or (b) ran — output goes into `docs/design_philosophy.md` "Reference Anchors"):
+   - **5 specific visual cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `OLED black #000 + #0A0A0A surface`, `SF Pro Display 34/40 + SF Mono 13`) — **source image path under `docs/references/` OR user-provided image URL/path**.
+   - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
+   - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a Material/HIG default. Prose-only cues are rejected.
+   - Never invent hex / font / spacing values without an image to point at. Mark uncertain extractions with `≈` and cite the source image.
 8) Commit to a BOLD aesthetic direction with mobile lens:
    - Apply the mobile design lens: one-handed usability, first 3-second impression, memorable gestures
 9) Generate `docs/design_philosophy.md`:
@@ -114,14 +133,14 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
        - "List items use `borderLeftWidth: 4` in `colors.accent` on the focused/active row only — no background highlight"
        - "FABs offset 16pt above the home indicator and overhang the safe area by -12pt — never centered"
        - "Bottom sheet snap points: 35% / 70% / 100% with `swipeDownEnabled` + Haptic.Light on snap"
-   - **Reference Anchors** section (from step 7.5 visual research): 5 adopted cues with source URLs, 3–5 avoided cues with reasons.
+   - **Reference Anchors** section (from step 7.5 image-grounded research): 5 adopted cues each citing an image (path under `docs/references/` or a user-provided image URL/path), 3–5 avoided cues with reasons. If step 7.5 took Path (c) and skipped this section, omit it here too and proceed.
    - What makes this design UNFORGETTABLE (should align with and reinforce the Signature Move).
 10) Present the design philosophy to the user and ask for approval before proceeding.
     - If rejected, iterate on the direction.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
-> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) **Reference Anchors** with 5 adopted cues each carrying a source URL.
-> If the Signature Move is prose-only, or Reference Anchors lack source URLs: STOP and fix before proceeding.
+> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line. If Reference Anchors is present, every adopted cue MUST cite an image path under `docs/references/` or a user-provided image URL/path — NOT a generic webpage URL that was WebFetched.
+> If the Signature Move is prose-only, or Reference Anchors lacks image citations, or Reference Anchors has 0 cues without an explicit skip line: STOP and fix before proceeding.
 
 ### Phase 3 — Mobile Design System
 11) Generate `docs/design_system_mobile.md` reflecting the chosen aesthetic:

--- a/skills/uiux/SKILL.md
+++ b/skills/uiux/SKILL.md
@@ -4,7 +4,7 @@ name: uiux
 description: Establishes a design philosophy based on kickoff outputs, and generates a design system/wireframes/HTML prototype. Recommended flow: /prd → /kickoff → /uiux
 argument-hint: [PRD.md path (optional)]
 disable-model-invocation: false
-allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
+allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
 ---
 
 ## Kit Preamble — uiux
@@ -111,19 +111,38 @@ If the result is `true`:
    - Who are the users? What's the emotional tone?
    - What category does this product belong to? (SaaS, consumer, creative tool, enterprise, etc.)
    - Are there competitor/reference products mentioned?
-6.5) **Reference Research** (uses WebSearch + WebFetch):
-   - Step 1 — Source discovery via WebSearch:
-     - Aspiration reference: `"[brand/product] UI design site:dribbble.com OR site:mobbin.com OR site:awwwards.com OR site:land-book.com OR site:godly.website"`
-     - Anti-reference: `"[anti-reference] UI criticism"`
-     - Domain trends: `"[domain] app design 2025 2026 showcase"`
-   - Step 2 — Visual fetching via WebFetch (CRITICAL — do not skip):
-     - From the search results, pick 2–3 URLs that point to actual visual showcases (gallery pages, case studies, product hero pages, brand press kits) — NOT text-only articles.
-     - WebFetch each URL. Extract concrete visual specifics: exact hex colors, specific font pairings, layout choice (asymmetric grid, full-bleed photo, type-as-art hero, etc.), background treatment (gradient mesh, noise, plain), shadow style, motion cues.
-     - If WebFetch returns text-only without resolvable visuals, fall back to careful synthesis from the page description but mark the cue as `(indirect)` so the implementer knows confidence is lower.
-   - Step 3 — Synthesis (output goes into `docs/design_philosophy.md` "Reference Anchors"):
-     - **5 specific visual cues to adopt**, each as a single bullet with: cue (≤12 words) — exact value or token (e.g., `#1A1A1A on #F5EFE6`, `Fraunces 96/0.92 + Inter Tight 14`) — source URL.
-     - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
-     - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a default. Prose-only cues like "warm palette" or "bold type" are rejected — re-do them with numbers/tokens.
+6.5) **Reference Research — image-grounded only** (NO WebFetch for visual extraction).
+
+   WebFetch returns parsed text, not pixels. Asking the model to extract hex values or font pairings from a Dribbble/Mobbin URL via WebFetch is fabrication. Visual references MUST arrive as actual images.
+
+   Pick exactly ONE of three paths:
+
+   - **Path (a) — user-provided images** (preferred):
+     - The user supplies 1–3 image references (image URLs ending in `.png`/`.jpg`/`.webp` OR local file paths).
+     - Read each image with the Read tool (image input). The model sees actual pixels.
+     - For each image, extract concrete cues from what you actually see: dominant hex color guesses, font category guesses (serif/grotesque/mono with weight), composition (grid, density, alignment), background treatment, shadow style. Mark guesses with "≈" when sampling color from rendered output.
+
+   - **Path (b) — page URLs**:
+     - For each reference page URL, run:
+       ```bash
+       python3 scripts/capture_reference.py <url>
+       ```
+       This headless-captures the page to `docs/references/<slug>.png`. If the script exits non-zero (no browser backend installed), STOP this path and either install Playwright/Chromium OR switch to Path (a) OR Path (c).
+     - Read every captured PNG via the Read tool.
+     - Extract the same kinds of cues as Path (a), grounded in the captured image.
+
+   - **Path (c) — no images available**:
+     - Skip the Reference Anchors section entirely. Print this one-line warning to the user:
+       `Reference Anchor skipped: no image provided. Pass 1–3 image paths or a page URL (with Playwright/Chrome installed) to populate this section.`
+     - Proceed to Phase 2 step 7 (aesthetic direction) WITHOUT a Reference Anchors section. The Signature Move + Decision Matrix still anchor the design — references are an additional, not required, signal.
+
+   **Anti-reference (separate from path choice)**: WebSearch is still acceptable for *titles* of anti-references (e.g., "what makes corporate B2B SaaS dashboards generic"). Anti-cues are written from the model's own knowledge of the pattern being avoided — they are not visual extractions and do not require image grounding.
+
+   **Synthesis** (when Path (a) or (b) ran successfully — output goes into `docs/design_philosophy.md` "Reference Anchors"):
+   - **5 specific visual cues to adopt**, each as a single bullet with: cue (≤12 words) — exact value or token (e.g., `#1A1A1A on #F5EFE6`, `Fraunces 96/0.92 + Inter Tight 14`) — **source image path under `docs/references/` OR the user-provided image URL**.
+   - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
+   - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a default. Prose-only cues like "warm palette" or "bold type" are rejected — re-do them with numbers/tokens.
+   - Never invent a hex value or font name without an image to point at. If an extracted detail is uncertain, mark it `≈` (approximate) and leave a comment about which image it came from.
 7) Commit to a BOLD aesthetic direction. Choose one and execute with precision:
    - Brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined,
      playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel,
@@ -143,14 +162,14 @@ If the result is `true`:
        - "Section dividers: `1px solid var(--accent)` with `margin-right: 12px` indent — never full-width rules"
        - "Screen titles: Fraunces 96/0.92, `letter-spacing: -0.04em`, `transform: skew(-2deg)`"
        - "All hover states: `translateY(-2px)` + `border-left: 4px solid var(--ink)` — no opacity changes"
-   - **Reference Anchors** section (from step 6.5 visual research): 5 adopted cues with source URLs, 3–5 avoided cues with reasons.
+   - **Reference Anchors** section (from step 6.5 image-grounded research): 5 adopted cues each pointing at an image (path under `docs/references/` or a user-provided image URL/path), 3–5 avoided cues with reasons. If step 6.5 took Path (c) and skipped this section, omit it here too and proceed.
    - What makes this design UNFORGETTABLE — the one thing someone will remember (should align with and reinforce the Signature Move).
 9) Present the design philosophy to the user and ask for approval before proceeding.
    - If rejected, iterate on the direction.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
-> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) **Reference Anchors** with 5 adopted cues each carrying a source URL.
-> If the Signature Move is prose-only, or Reference Anchors lack source URLs: STOP and fix before proceeding.
+> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line. If Reference Anchors is present, every adopted cue MUST cite an image path under `docs/references/` or a user-provided image URL/path — NOT a generic webpage URL that was WebFetched.
+> If the Signature Move is prose-only, or Reference Anchors lacks image citations, or Reference Anchors has 0 cues without an explicit skip line: STOP and fix before proceeding.
 
 ### Phase 3 — Design System
 9) Generate `docs/design_system.md` reflecting the chosen aesthetic:

--- a/skills/uiux/SKILL.md.tmpl
+++ b/skills/uiux/SKILL.md.tmpl
@@ -3,7 +3,7 @@ name: uiux
 description: Establishes a design philosophy based on kickoff outputs, and generates a design system/wireframes/HTML prototype. Recommended flow: /prd → /kickoff → /uiux
 argument-hint: [PRD.md path (optional)]
 disable-model-invocation: false
-allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
+allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
 ---
 
 {{PREAMBLE}}
@@ -75,19 +75,38 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
    - Who are the users? What's the emotional tone?
    - What category does this product belong to? (SaaS, consumer, creative tool, enterprise, etc.)
    - Are there competitor/reference products mentioned?
-6.5) **Reference Research** (uses WebSearch + WebFetch):
-   - Step 1 — Source discovery via WebSearch:
-     - Aspiration reference: `"[brand/product] UI design site:dribbble.com OR site:mobbin.com OR site:awwwards.com OR site:land-book.com OR site:godly.website"`
-     - Anti-reference: `"[anti-reference] UI criticism"`
-     - Domain trends: `"[domain] app design 2025 2026 showcase"`
-   - Step 2 — Visual fetching via WebFetch (CRITICAL — do not skip):
-     - From the search results, pick 2–3 URLs that point to actual visual showcases (gallery pages, case studies, product hero pages, brand press kits) — NOT text-only articles.
-     - WebFetch each URL. Extract concrete visual specifics: exact hex colors, specific font pairings, layout choice (asymmetric grid, full-bleed photo, type-as-art hero, etc.), background treatment (gradient mesh, noise, plain), shadow style, motion cues.
-     - If WebFetch returns text-only without resolvable visuals, fall back to careful synthesis from the page description but mark the cue as `(indirect)` so the implementer knows confidence is lower.
-   - Step 3 — Synthesis (output goes into `docs/design_philosophy.md` "Reference Anchors"):
-     - **5 specific visual cues to adopt**, each as a single bullet with: cue (≤12 words) — exact value or token (e.g., `#1A1A1A on #F5EFE6`, `Fraunces 96/0.92 + Inter Tight 14`) — source URL.
-     - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
-     - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a default. Prose-only cues like "warm palette" or "bold type" are rejected — re-do them with numbers/tokens.
+6.5) **Reference Research — image-grounded only** (NO WebFetch for visual extraction).
+
+   WebFetch returns parsed text, not pixels. Asking the model to extract hex values or font pairings from a Dribbble/Mobbin URL via WebFetch is fabrication. Visual references MUST arrive as actual images.
+
+   Pick exactly ONE of three paths:
+
+   - **Path (a) — user-provided images** (preferred):
+     - The user supplies 1–3 image references (image URLs ending in `.png`/`.jpg`/`.webp` OR local file paths).
+     - Read each image with the Read tool (image input). The model sees actual pixels.
+     - For each image, extract concrete cues from what you actually see: dominant hex color guesses, font category guesses (serif/grotesque/mono with weight), composition (grid, density, alignment), background treatment, shadow style. Mark guesses with "≈" when sampling color from rendered output.
+
+   - **Path (b) — page URLs**:
+     - For each reference page URL, run:
+       ```bash
+       python3 scripts/capture_reference.py <url>
+       ```
+       This headless-captures the page to `docs/references/<slug>.png`. If the script exits non-zero (no browser backend installed), STOP this path and either install Playwright/Chromium OR switch to Path (a) OR Path (c).
+     - Read every captured PNG via the Read tool.
+     - Extract the same kinds of cues as Path (a), grounded in the captured image.
+
+   - **Path (c) — no images available**:
+     - Skip the Reference Anchors section entirely. Print this one-line warning to the user:
+       `Reference Anchor skipped: no image provided. Pass 1–3 image paths or a page URL (with Playwright/Chrome installed) to populate this section.`
+     - Proceed to Phase 2 step 7 (aesthetic direction) WITHOUT a Reference Anchors section. The Signature Move + Decision Matrix still anchor the design — references are an additional, not required, signal.
+
+   **Anti-reference (separate from path choice)**: WebSearch is still acceptable for *titles* of anti-references (e.g., "what makes corporate B2B SaaS dashboards generic"). Anti-cues are written from the model's own knowledge of the pattern being avoided — they are not visual extractions and do not require image grounding.
+
+   **Synthesis** (when Path (a) or (b) ran successfully — output goes into `docs/design_philosophy.md` "Reference Anchors"):
+   - **5 specific visual cues to adopt**, each as a single bullet with: cue (≤12 words) — exact value or token (e.g., `#1A1A1A on #F5EFE6`, `Fraunces 96/0.92 + Inter Tight 14`) — **source image path under `docs/references/` OR the user-provided image URL**.
+   - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
+   - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a default. Prose-only cues like "warm palette" or "bold type" are rejected — re-do them with numbers/tokens.
+   - Never invent a hex value or font name without an image to point at. If an extracted detail is uncertain, mark it `≈` (approximate) and leave a comment about which image it came from.
 7) Commit to a BOLD aesthetic direction. Choose one and execute with precision:
    - Brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined,
      playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel,
@@ -107,14 +126,14 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
        - "Section dividers: `1px solid var(--accent)` with `margin-right: 12px` indent — never full-width rules"
        - "Screen titles: Fraunces 96/0.92, `letter-spacing: -0.04em`, `transform: skew(-2deg)`"
        - "All hover states: `translateY(-2px)` + `border-left: 4px solid var(--ink)` — no opacity changes"
-   - **Reference Anchors** section (from step 6.5 visual research): 5 adopted cues with source URLs, 3–5 avoided cues with reasons.
+   - **Reference Anchors** section (from step 6.5 image-grounded research): 5 adopted cues each pointing at an image (path under `docs/references/` or a user-provided image URL/path), 3–5 avoided cues with reasons. If step 6.5 took Path (c) and skipped this section, omit it here too and proceed.
    - What makes this design UNFORGETTABLE — the one thing someone will remember (should align with and reinforce the Signature Move).
 9) Present the design philosophy to the user and ask for approval before proceeding.
    - If rejected, iterate on the direction.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
-> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) **Reference Anchors** with 5 adopted cues each carrying a source URL.
-> If the Signature Move is prose-only, or Reference Anchors lack source URLs: STOP and fix before proceeding.
+> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line. If Reference Anchors is present, every adopted cue MUST cite an image path under `docs/references/` or a user-provided image URL/path — NOT a generic webpage URL that was WebFetched.
+> If the Signature Move is prose-only, or Reference Anchors lacks image citations, or Reference Anchors has 0 cues without an explicit skip line: STOP and fix before proceeding.
 
 ### Phase 3 — Design System
 9) Generate `docs/design_system.md` reflecting the chosen aesthetic:

--- a/tests/test_capture_reference.py
+++ b/tests/test_capture_reference.py
@@ -1,0 +1,84 @@
+"""Unit tests for scripts/capture_reference.py."""
+
+import pytest
+
+from scripts.capture_reference import main, slug_from_url
+
+
+class TestSlugFromUrl:
+    @pytest.mark.parametrize(
+        ("url", "expected_contains"),
+        [
+            ("https://linear.app/", "linear-app"),
+            ("https://linear.app/method", "linear-app-method"),
+            ("https://example.com/path/to/page", "example-com-path-to-page"),
+            ("https://a.b.c.com/", "a-b-c-com"),
+        ],
+    )
+    def test_derives_slug(self, url: str, expected_contains: str):
+        slug = slug_from_url(url)
+        assert expected_contains in slug
+
+    def test_strips_trailing_dashes(self):
+        slug = slug_from_url("https://example.com////")
+        assert not slug.endswith("-")
+
+    def test_caps_length(self):
+        long_path = "/" + "a" * 200
+        slug = slug_from_url(f"https://example.com{long_path}")
+        assert len(slug) <= 80
+
+
+class TestMainCli:
+    def test_rejects_non_http_url(self, capsys: pytest.CaptureFixture):
+        rc = main(["ftp://example.com"])
+        assert rc == 2
+        assert "http://" in capsys.readouterr().err
+
+    def test_rejects_bad_viewport(self, capsys: pytest.CaptureFixture):
+        # URL is well-formed but viewport is garbage — should fail before any backend call.
+        rc = main(["https://example.com", "--viewport", "garbage"])
+        assert rc == 2
+        assert "viewport" in capsys.readouterr().err
+
+    def test_no_backend_returns_3(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+        capsys: pytest.CaptureFixture,
+    ):
+        # Stub both backends to fail; assert we get the install-instructions error
+        # without actually launching a browser.
+        from scripts import capture_reference
+
+        monkeypatch.setattr(capture_reference, "try_playwright", lambda *a, **kw: False)
+        monkeypatch.setattr(capture_reference, "try_chrome", lambda *a, **kw: False)
+
+        out = tmp_path / "ref.png"
+        rc = main(["https://example.com", "--out", str(out)])
+        assert rc == 3
+        err = capsys.readouterr().err
+        assert "no screenshot backend" in err
+        assert "image paths directly" in err  # skip path is documented
+
+    def test_playwright_success_writes_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+        capsys: pytest.CaptureFixture,
+    ):
+        from scripts import capture_reference
+
+        out = tmp_path / "out.png"
+
+        def fake_playwright(url, target, viewport):
+            target.write_bytes(b"\x89PNG\r\n\x1a\n")  # 8-byte PNG signature stub
+            return True
+
+        monkeypatch.setattr(capture_reference, "try_playwright", fake_playwright)
+        monkeypatch.setattr(capture_reference, "try_chrome", lambda *a, **kw: False)
+
+        rc = main(["https://example.com", "--out", str(out)])
+        assert rc == 0
+        assert out.exists()
+        assert "playwright" in capsys.readouterr().out

--- a/tests/test_uiux_reference_fabrication_guard.py
+++ b/tests/test_uiux_reference_fabrication_guard.py
@@ -1,0 +1,90 @@
+"""Regression guard for ISSUE-011.
+
+WebFetch returns parsed text, not pixels. The uiux skills must not instruct
+the model to "WebFetch a URL and extract hex colors / fonts / proportions" —
+that pattern fabricates values regardless of the disclaimer.
+
+This test scans the three uiux skill templates and the docs for any
+remaining "WebFetch ... extract" instruction shape. Any explicit negation
+("NO WebFetch for visual extraction") is allowed; the goal is to prevent
+re-introduction of the fabrication shape.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+UIUX_TMPL_PATHS = [
+    Path("skills/uiux/SKILL.md.tmpl"),
+    Path("skills/mobile-uiux/SKILL.md.tmpl"),
+    Path("skills/desktop-uiux/SKILL.md.tmpl"),
+]
+
+# Forbidden shape: WebFetch followed (within a few words) by extract/extracting,
+# in a context where the model is being told to derive visual specifics.
+FABRICATION_SHAPE = re.compile(
+    r"WebFetch[^.\n]{0,80}\bextract\b",
+    re.IGNORECASE,
+)
+
+# Allowed negations — these explicitly tell the model NOT to use WebFetch this way.
+NEGATION_TOKENS = ("NO WebFetch", "not WebFetch", "no longer uses WebFetch")
+
+
+def _is_negation_line(line: str) -> bool:
+    return any(tok.lower() in line.lower() for tok in NEGATION_TOKENS)
+
+
+def test_no_webfetch_extract_pattern_in_uiux_templates():
+    offenders: list[tuple[str, int, str]] = []
+    for tmpl in UIUX_TMPL_PATHS:
+        assert tmpl.exists(), f"missing template: {tmpl}"
+        text = tmpl.read_text(encoding="utf-8")
+        for line_no, line in enumerate(text.splitlines(), 1):
+            if FABRICATION_SHAPE.search(line) and not _is_negation_line(line):
+                offenders.append((str(tmpl), line_no, line.strip()))
+
+    assert not offenders, (
+        "WebFetch-extract pattern resurfaced in uiux templates "
+        "(should be image-grounded only — see ISSUE-011):\n"
+        + "\n".join(f"  {p}:{n}: {ln}" for p, n, ln in offenders)
+    )
+
+
+def test_uiux_templates_reference_capture_script():
+    """Every uiux template should mention scripts/capture_reference.py so users
+    have a non-WebFetch path for URL-based references."""
+    for tmpl in UIUX_TMPL_PATHS:
+        text = tmpl.read_text(encoding="utf-8")
+        assert "capture_reference.py" in text, (
+            f"{tmpl} does not mention scripts/capture_reference.py; "
+            "Path (b) URL → PNG fallback is missing."
+        )
+
+
+def test_uiux_templates_have_skip_path():
+    """Every uiux template must allow proceeding without references (Path c)
+    so missing browser backend / no images doesn't silently fabricate."""
+    for tmpl in UIUX_TMPL_PATHS:
+        text = tmpl.read_text(encoding="utf-8")
+        # Look for the canonical skip warning shape.
+        assert "Reference Anchor skipped" in text, (
+            f"{tmpl} does not provide an explicit skip path for the case "
+            "where no images are available."
+        )
+
+
+def test_webfetch_removed_from_allowed_tools():
+    """The three uiux skills should not include WebFetch in allowed-tools —
+    removing the affordance is the strongest guard against regression."""
+    for tmpl in UIUX_TMPL_PATHS:
+        text = tmpl.read_text(encoding="utf-8")
+        frontmatter = text.split("---", 2)[1] if text.startswith("---") else text
+        m = re.search(r"^allowed-tools:\s*(.+)$", frontmatter, re.MULTILINE)
+        assert m, f"{tmpl} has no allowed-tools line"
+        tools = [t.strip() for t in m.group(1).split(",")]
+        assert "WebFetch" not in tools, (
+            f"{tmpl} still lists WebFetch in allowed-tools — removing the "
+            "affordance is the structural guarantee against ISSUE-011 regression."
+        )


### PR DESCRIPTION
## Summary
- `WebFetch` returns parsed text, not pixels. Asking the model to extract hex/font values from a Dribbble URL via `WebFetch` is **fabrication** regardless of the `(indirect)` disclaimer.
- This PR makes the failure mode structurally impossible by removing `WebFetch` from the uiux skills' `allowed-tools`.
- Phase 2 Reference Research now picks ONE of three explicit paths:
  - **Path (a)** user-provided image URLs/paths → Read directly
  - **Path (b)** page URL → `scripts/capture_reference.py` captures to PNG → Read
  - **Path (c)** no images → skip Reference Anchors with a one-line warning
- Reference Anchors must cite an image path (`docs/references/<slug>.png` or user-provided image URL/path), not a generic webpage URL.
- 4 regression-guard tests prevent the WebFetch-extract pattern from resurfacing.
- Self-documents: `docs/specs/SPEC-011.md`.

## Test plan
- [x] `pytest tests/test_capture_reference.py` — 10 passed (slug derivation, CLI errors, no-backend exit, success stub)
- [x] `pytest tests/test_uiux_reference_fabrication_guard.py` — 4 passed (no WebFetch-extract pattern, capture script mentioned, skip path present, WebFetch removed from allowed-tools)
- [x] `python3 scripts/gen_skills.py --dry-run` — all 25 SKILL.md files fresh
- [x] `python3 scripts/validate_issues.py issues.md` — 13/13 pass
- [x] `python3 scripts/validate_spec.py docs/specs/` — all 3 SPECs pass
- [ ] Manual: run `/uiux` on a real project with image references; verify the Path (a) instruction is followed
- [ ] Manual: install Playwright, run `scripts/capture_reference.py https://linear.app/` and verify the PNG appears under `docs/references/`

## Notes
- Anti-reference research still uses `WebSearch` for *titles* of criticism articles; anti-cues are written from the model's own pattern knowledge, not extracted from page text.
- Users in browser-less environments lose the URL path and must use Path (a) or Path (c) — documented in the skip warning.

Closes ISSUE-011

🤖 Generated with [Claude Code](https://claude.com/claude-code)