### PR TITLE
feat(uiux): tune Reference Anchors to 2-3 cues + literal_quote (ISSUE-012)

### DIFF
--- a/docs/specs/SPEC-012.md
+++ b/docs/specs/SPEC-012.md
@@ -1,0 +1,81 @@
+# SPEC-012: Reference Anchor tuning — 2–3 strong cues + 1 literal_quote
+
+> Linked Issue: ISSUE-012
+> Status: `accepted`
+> Date: 2026-06-14
+> Author: claude-dev-kit
+
+## Problem
+
+Phase 2 Reference Anchor required "5 specific visual cues to adopt." Reviewers observed that 5 cues create **averaging pressure** — the model picks safe, generic cues across the set and the chosen direction degrades to "generic premium SaaS." Separately, the kit lacks an anchor that forces the prototype to render **brand-specific verbatim content**, so a Signature Move can be implemented while the prototype still reads as a sample app for a generic SaaS product.
+
+## Context
+
+- ISSUE-011 just landed image-grounded references — anchors now cite real pixels, not WebFetch fabrications.
+- The reviewer who flagged "averaging pressure" suggested 2–3 strong cues + 1 literal quote (a specific word, number, glyph, or shortcut drawn from the brand/domain).
+- ISSUE-010 (Pilot Gate hardening) needs a specificity check: "3 details that ONLY make sense for THIS product." The literal_quote becomes one of those 3 details.
+- The three uiux templates (`/uiux`, `/mobile-uiux`, `/desktop-uiux`) all carry the same Reference Anchor pattern.
+
+## Options
+
+### Option A: Reduce to 2–3 strong cues + mandatory literal_quote + verbatim render check
+- **Approach**: Change "5 cues" → "2–3 strong cues" in all three templates. Add a `literal_quote:` field requirement (skippable only if Phase 1.5 interview was explicitly skipped). Phase 2 CHECKPOINT enforces the field is populated; Phase 5.x verification phase grep-checks the literal string appears verbatim in rendered output.
+- **Pros**:
+  - Fewer-and-deeper cues remove averaging pressure.
+  - The literal_quote provides one of the 3 product-specific details ISSUE-010 will require.
+  - The verbatim grep is mechanical — Phase 5 can verify without LLM reasoning.
+- **Cons**:
+  - Two changes (cue count + literal_quote) in one PR — slightly higher review surface.
+- **Trade-off**: +1 mandatory field (literal_quote) per template, +1 verification step per template (~30 lines each), +1 guard test file (6 cases); -2 anchored cues per spec; -100% averaging pressure from 5-cue spec.
+
+### Option B: Reduce cue count only, no literal_quote
+- **Approach**: Change "5 cues" → "2–3 strong cues" but skip the literal_quote.
+- **Pros**:
+  - Smaller change, easier to review.
+- **Cons**:
+  - Loses the strongest specificity anchor — the prototype can still render generic copy/numbers.
+  - ISSUE-010's specificity check has nothing concrete to anchor on.
+- **Trade-off**: -1 mandatory field vs A, -1 verification step; -100% on the strongest specificity guarantee.
+
+### Option C: Add literal_quote only, keep 5 cues
+- **Approach**: Add literal_quote but leave cue count at 5.
+- **Pros**:
+  - No averaging-pressure debate.
+- **Cons**:
+  - The reviewer's "averaging pressure" diagnosis was the more cited concern.
+  - 5 generic cues + 1 strong literal_quote still averages out in practice.
+- **Trade-off**: vs A, +0 averaging-pressure relief; +100% on literal_quote anchor but lose the cue-density win.
+
+## Decision
+
+**Chosen: Option A.**
+
+The trade-off line "+1 mandatory field, +1 verification step, +1 guard test, -2 anchored cues, -100% averaging pressure" wins because both changes work together — the smaller cue set forces deeper specificity per cue, and the literal_quote turns "specific" from a property of cue text into a property of rendered output. Doing one without the other (Option B or C) achieves less than half the value at almost the same cost.
+
+## Trade-offs Accepted
+
+- Some teams prefer the 5-cue ritual for thoroughness; this PR reframes it as a slop vector. Documented in the SPEC and skill body.
+- The literal_quote MUST be concrete text — adjectives like "luxury", "trust", "premium" are rejected at the field level. This is a hard requirement; teams that want abstract "vibe" anchors will not have them.
+- When Phase 1.5 interview is skipped (user opt-out), literal_quote becomes optional. The CHECKPOINT records this with `literal_quote: (skipped — interview not run)` so future readers know it was deliberate.
+- The verbatim grep is exact-string only — no substring or normalization. A literal_quote `"47.2-A"` does NOT match `47-2-A`. This deliberate strictness prevents partial-match drift.
+
+## Migration
+
+1. Edit `skills/uiux/SKILL.md.tmpl`, `skills/mobile-uiux/SKILL.md.tmpl`, `skills/desktop-uiux/SKILL.md.tmpl`:
+   - Phase 2 step 6.5 / 7.5 synthesis section: "5 specific visual cues" → "2–3 strong cues" + add the `literal_quote:` block with concrete examples per platform.
+   - Downstream `design_philosophy.md` output spec: cue count updated, `literal_quote:` field declared.
+   - Phase 2 CHECKPOINT block: enforces (a) Signature Move, (b) skip-or-present, (c) 2–3 cues + literal_quote populated (or `(skipped — interview not run)`).
+   - Phase 5.x prototype verification: new "Literal quote verbatim render check" step grep-checks the literal string in `prototype/screens/*.html`, `prototype-mobile/src/screens/*.tsx`, or `prototype-desktop/src/screens/*.tsx`.
+2. Regenerate SKILL.md via `scripts/gen_skills.py`.
+3. Land `tests/test_reference_anchor_tuning.py` with 6 cases.
+4. No data migration — existing `design_philosophy.md` files keep their old anchors and degrade quietly. Re-running `/uiux` (e.g., for new sprints) lands the new format.
+
+## Rollback
+
+Revert the three SKILL.md.tmpl edits. Regenerate SKILL.md. Delete `tests/test_reference_anchor_tuning.py`. Existing `design_philosophy.md` files with new-format anchors continue to work — the validator does not reject them, just no longer enforces them. Rollback time: < 5 minutes.
+
+## Open Questions
+
+- [ ] Should the literal_quote verbatim grep be a separate machine-checked script (e.g., `scripts/verify_literal_quote.py`) instead of an in-skill instruction? — owner: design, by: when a real /uiux run shows the instruction is being skipped.
+- [ ] Should anti-cues also adopt fewer-and-deeper (currently 3–5)? — owner: design, by: when reviewers observe averaging pressure on the anti side too.
+- [ ] Should the cue count vary by archetype (e.g., 2 cues for minimalist directions, 3 for maximalist)? — owner: design, by: after 5 real /uiux runs land enough data to calibrate.

--- a/issues.md
+++ b/issues.md
@@ -28,7 +28,6 @@
 - [ ] ISSUE-008: Virtual monorepo wrapper — polyrepo team support _(track: platform, P2, 1.5d)_
 - [ ] ISSUE-009: Install script --pack flag + merge_settings + tests _(track: platform, P1, 1.5d)_
 - [ ] ISSUE-010: Pilot Gate hardening — separate-context critic + auto-cycle + neutral observation + specificity check _(track: platform, P2, 1.5d)_
-- [ ] ISSUE-012: Reference Anchor tuning — 2-3 strong cues + 1 literal quote _(track: platform, P2, 0.5d)_
 
 ### Doing
 
@@ -38,6 +37,7 @@
 - [x] ISSUE-006: /spec skill — RFC pattern + Spec-Required metadata + non-sprint HOLD gate _(track: platform, P1, 1.5d)_
 - [x] ISSUE-007: /implement spec gate — sprint auto-run + non-sprint HOLD + signal detection _(track: platform, P1, 1d)_
 - [x] ISSUE-011: Kill WebFetch reference fabrication — image-grounded references only _(track: platform, P1, 0.5d)_
+- [x] ISSUE-012: Reference Anchor tuning — 2-3 strong cues + 1 literal quote _(track: platform, P2, 0.5d)_
 - [x] ISSUE-013: Consolidate ui-reviewer / design-auditor agents — sharpen role boundaries _(track: platform, P2, 1d)_
 
 ### Drop
@@ -728,10 +728,12 @@ Revert SKILL.md changes in the three uiux skills. Delete `scripts/capture_refere
 - UI: false
 - Platform: web
 - Manual: false
+- Spec-Required: true
+- Spec: docs/specs/SPEC-012.md
 - PRD-Ref: none (kit self-development; rationale in conversation 2026-06-13 — 5 anchors create averaging pressure; a single literal quote injects product-specific concreteness at Phase 2)
 - Priority: P2
 - Estimate: 0.5d
-- Status: backlog
+- Status: done
 - Owner:
 - Branch:
 - GH-Issue:

--- a/skills/desktop-uiux/SKILL.md
+++ b/skills/desktop-uiux/SKILL.md
@@ -153,10 +153,17 @@ If the result is `true`:
    **Anti-reference**: WebSearch for *anti-reference titles* is acceptable. Anti-cues are written from the model's own knowledge.
 
    **Synthesis** (when Path (a) or (b) ran — output goes into `docs/design_philosophy.md` "Reference Anchors"):
-   - **5 specific visual cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `sidebar 240px @ #0E0F12`, `JetBrains Mono 13 + Inter 13`, `title bar 28px frameless with traffic lights inset 12/12`) — **source image path under `docs/references/` OR user-provided image URL/path**.
+   - **2–3 strong cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `sidebar 240px @ #0E0F12`, `JetBrains Mono 13 + Inter 13`, `title bar 28px frameless with traffic lights inset 12/12`) — **source image path under `docs/references/` OR user-provided image URL/path**. Strong = present in the chosen images, specific enough that no Phase 5 implementer can fall back to a generic Electron/Material default. Fewer-and-deeper beats more-and-shallow.
+   - **1 literal quote** (MANDATORY when Phase 1.5 interview was NOT skipped): a specific word, number, glyph, or shortcut drawn from the brand or domain that MUST appear **verbatim** in the rendered prototype. Format: `literal_quote: "<exact string>" — <where it appears>`. Desktop-friendly examples:
+     - `literal_quote: "⌘K" — command palette trigger shown in the sidebar`
+     - `literal_quote: "47.2-A" — sample order ID, mono on the order detail panel`
+     - `literal_quote: "조용한" — set in 96pt Inter Display, splash screen`
+     - Reject abstract concepts (`"luxury"`, `"power user"`) — the literal quote is text/glyph/shortcut the prototype renders.
    - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
    - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a generic Electron/Material default. Prose-only cues are rejected.
    - Never invent hex / font / sizing values without an image to point at. Mark uncertain extractions with `≈` and cite the source image.
+
+   **Verbatim render check** — Phase 5B is required to render the `literal_quote` string verbatim in at least one screen file under `prototype-desktop/`. The Phase 2 CHECKPOINT below verifies the field is populated; Phase 5B verifies it appears in rendered output.
 8) Commit to a BOLD aesthetic direction with desktop lens:
    - Apply the desktop design lens: information density, keyboard workflow, multi-window experience
 9) Generate `docs/design_philosophy.md`:
@@ -173,14 +180,17 @@ If the result is `true`:
        - "Command palette: `clip-path: polygon(...)` notched bottom-right corner, 480×320 fixed — never plain rounded rectangle"
        - "Sidebar split: `grid-template-columns: 240px 1fr` with a 1px hairline divider in `--border-strong`, no shadow"
        - "Title bar: 28px frameless with traffic lights inset 12/12, app icon at 16px — never default window chrome"
-   - **Reference Anchors** section (from step 7.5 image-grounded research): 5 adopted cues each citing an image (path under `docs/references/` or a user-provided image URL/path), 3–5 avoided cues with reasons. If step 7.5 took Path (c) and skipped this section, omit it here too and proceed.
+   - **Reference Anchors** section (from step 7.5 image-grounded research): 2–3 strong adopted cues each citing an image (path under `docs/references/` or a user-provided image URL/path), 1 `literal_quote:` field (mandatory unless Phase 1.5 was skipped), 3–5 avoided cues with reasons. If step 7.5 took Path (c) and skipped this section, omit it here too and proceed.
    - What makes this design UNFORGETTABLE (should align with and reinforce the Signature Move).
 10) Present the design philosophy to the user and ask for approval before proceeding.
     - If rejected, iterate on the direction.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
-> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line. If Reference Anchors is present, every adopted cue MUST cite an image path under `docs/references/` or a user-provided image URL/path — NOT a generic webpage URL that was WebFetched.
-> If the Signature Move is prose-only, or Reference Anchors lacks image citations, or Reference Anchors has 0 cues without an explicit skip line: STOP and fix before proceeding.
+> Verify `docs/design_philosophy.md` exists with:
+> (a) a **Signature Move** that is numeric/token-specific (not prose-only);
+> (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line; AND
+> (c) when Reference Anchors is present, exactly **2–3** adopted cues (not 1, not 4+), each citing an image path, plus a `literal_quote:` field with a concrete word/number/glyph/shortcut (NOT an adjective like "luxury"). The literal_quote may only be omitted if Phase 1.5 interview was explicitly skipped — in which case `literal_quote: (skipped — interview not run)` must appear instead of the field being absent.
+> If any of (a) / (b) / (c) fails: STOP and fix before proceeding.
 
 ### Phase 3 — Desktop Design System
 11) Generate `docs/design_system_desktop.md` reflecting the chosen aesthetic:
@@ -422,6 +432,11 @@ If the result is `true`:
     - The Signature Move must be implemented as a reusable component/class/CSS-custom-property primitive under `src/components/` or `src/theme/`.
     - Every `.tsx` file in `src/screens/` (including the pilots) must reference that reusable Signature Move primitive at least once.
     - If any check fails: list violations, fix, and re-verify before proceeding.
+27.6) **Literal quote verbatim render check** (skip if Phase 1.5 was explicitly skipped):
+    - Read `literal_quote:` from `docs/design_philosophy.md` Reference Anchors.
+    - Grep `src/screens/*.tsx` for the literal string. The string MUST appear verbatim in at least one screen file (inside a string literal, NOT inside a comment).
+    - If absent: name the screens that would naturally host it (per the anchor's "where it appears" hint), inject the quote into that screen, and re-grep. Do not skip by widening the search.
+    - Example: `literal_quote: "⌘K"` MUST appear as the literal characters `⌘K` — not `Cmd+K`, not interpolated from a variable, not inside `{/* */}`.
 28) **Performance check**:
     - List/table item components MUST use `React.memo`
     - Event handlers passed to memoized children MUST use `useCallback`

--- a/skills/desktop-uiux/SKILL.md.tmpl
+++ b/skills/desktop-uiux/SKILL.md.tmpl
@@ -117,10 +117,17 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
    **Anti-reference**: WebSearch for *anti-reference titles* is acceptable. Anti-cues are written from the model's own knowledge.
 
    **Synthesis** (when Path (a) or (b) ran — output goes into `docs/design_philosophy.md` "Reference Anchors"):
-   - **5 specific visual cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `sidebar 240px @ #0E0F12`, `JetBrains Mono 13 + Inter 13`, `title bar 28px frameless with traffic lights inset 12/12`) — **source image path under `docs/references/` OR user-provided image URL/path**.
+   - **2–3 strong cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `sidebar 240px @ #0E0F12`, `JetBrains Mono 13 + Inter 13`, `title bar 28px frameless with traffic lights inset 12/12`) — **source image path under `docs/references/` OR user-provided image URL/path**. Strong = present in the chosen images, specific enough that no Phase 5 implementer can fall back to a generic Electron/Material default. Fewer-and-deeper beats more-and-shallow.
+   - **1 literal quote** (MANDATORY when Phase 1.5 interview was NOT skipped): a specific word, number, glyph, or shortcut drawn from the brand or domain that MUST appear **verbatim** in the rendered prototype. Format: `literal_quote: "<exact string>" — <where it appears>`. Desktop-friendly examples:
+     - `literal_quote: "⌘K" — command palette trigger shown in the sidebar`
+     - `literal_quote: "47.2-A" — sample order ID, mono on the order detail panel`
+     - `literal_quote: "조용한" — set in 96pt Inter Display, splash screen`
+     - Reject abstract concepts (`"luxury"`, `"power user"`) — the literal quote is text/glyph/shortcut the prototype renders.
    - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
    - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a generic Electron/Material default. Prose-only cues are rejected.
    - Never invent hex / font / sizing values without an image to point at. Mark uncertain extractions with `≈` and cite the source image.
+
+   **Verbatim render check** — Phase 5B is required to render the `literal_quote` string verbatim in at least one screen file under `prototype-desktop/`. The Phase 2 CHECKPOINT below verifies the field is populated; Phase 5B verifies it appears in rendered output.
 8) Commit to a BOLD aesthetic direction with desktop lens:
    - Apply the desktop design lens: information density, keyboard workflow, multi-window experience
 9) Generate `docs/design_philosophy.md`:
@@ -137,14 +144,17 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
        - "Command palette: `clip-path: polygon(...)` notched bottom-right corner, 480×320 fixed — never plain rounded rectangle"
        - "Sidebar split: `grid-template-columns: 240px 1fr` with a 1px hairline divider in `--border-strong`, no shadow"
        - "Title bar: 28px frameless with traffic lights inset 12/12, app icon at 16px — never default window chrome"
-   - **Reference Anchors** section (from step 7.5 image-grounded research): 5 adopted cues each citing an image (path under `docs/references/` or a user-provided image URL/path), 3–5 avoided cues with reasons. If step 7.5 took Path (c) and skipped this section, omit it here too and proceed.
+   - **Reference Anchors** section (from step 7.5 image-grounded research): 2–3 strong adopted cues each citing an image (path under `docs/references/` or a user-provided image URL/path), 1 `literal_quote:` field (mandatory unless Phase 1.5 was skipped), 3–5 avoided cues with reasons. If step 7.5 took Path (c) and skipped this section, omit it here too and proceed.
    - What makes this design UNFORGETTABLE (should align with and reinforce the Signature Move).
 10) Present the design philosophy to the user and ask for approval before proceeding.
     - If rejected, iterate on the direction.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
-> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line. If Reference Anchors is present, every adopted cue MUST cite an image path under `docs/references/` or a user-provided image URL/path — NOT a generic webpage URL that was WebFetched.
-> If the Signature Move is prose-only, or Reference Anchors lacks image citations, or Reference Anchors has 0 cues without an explicit skip line: STOP and fix before proceeding.
+> Verify `docs/design_philosophy.md` exists with:
+> (a) a **Signature Move** that is numeric/token-specific (not prose-only);
+> (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line; AND
+> (c) when Reference Anchors is present, exactly **2–3** adopted cues (not 1, not 4+), each citing an image path, plus a `literal_quote:` field with a concrete word/number/glyph/shortcut (NOT an adjective like "luxury"). The literal_quote may only be omitted if Phase 1.5 interview was explicitly skipped — in which case `literal_quote: (skipped — interview not run)` must appear instead of the field being absent.
+> If any of (a) / (b) / (c) fails: STOP and fix before proceeding.
 
 ### Phase 3 — Desktop Design System
 11) Generate `docs/design_system_desktop.md` reflecting the chosen aesthetic:
@@ -386,6 +396,11 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
     - The Signature Move must be implemented as a reusable component/class/CSS-custom-property primitive under `src/components/` or `src/theme/`.
     - Every `.tsx` file in `src/screens/` (including the pilots) must reference that reusable Signature Move primitive at least once.
     - If any check fails: list violations, fix, and re-verify before proceeding.
+27.6) **Literal quote verbatim render check** (skip if Phase 1.5 was explicitly skipped):
+    - Read `literal_quote:` from `docs/design_philosophy.md` Reference Anchors.
+    - Grep `src/screens/*.tsx` for the literal string. The string MUST appear verbatim in at least one screen file (inside a string literal, NOT inside a comment).
+    - If absent: name the screens that would naturally host it (per the anchor's "where it appears" hint), inject the quote into that screen, and re-grep. Do not skip by widening the search.
+    - Example: `literal_quote: "⌘K"` MUST appear as the literal characters `⌘K` — not `Cmd+K`, not interpolated from a variable, not inside `{/* */}`.
 28) **Performance check**:
     - List/table item components MUST use `React.memo`
     - Event handlers passed to memoized children MUST use `useCallback`

--- a/skills/mobile-uiux/SKILL.md
+++ b/skills/mobile-uiux/SKILL.md
@@ -149,10 +149,17 @@ If the result is `true`:
    **Anti-reference**: WebSearch for *anti-reference titles* is acceptable. Anti-cues are written from the model's own knowledge of patterns being avoided.
 
    **Synthesis** (when Path (a) or (b) ran — output goes into `docs/design_philosophy.md` "Reference Anchors"):
-   - **5 specific visual cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `OLED black #000 + #0A0A0A surface`, `SF Pro Display 34/40 + SF Mono 13`) — **source image path under `docs/references/` OR user-provided image URL/path**.
+   - **2–3 strong cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `OLED black #000 + #0A0A0A surface`, `SF Pro Display 34/40 + SF Mono 13`) — **source image path under `docs/references/` OR user-provided image URL/path**. Strong = present in the chosen images, specific enough that no Phase 5 implementer can fall back to a Material/HIG default. Fewer-and-deeper beats more-and-shallow.
+   - **1 literal quote** (MANDATORY when Phase 1.5 interview was NOT skipped): a specific word, number, or glyph drawn from the brand or domain that MUST appear **verbatim** in the rendered prototype screens. Format: `literal_quote: "<exact string>" — <where it appears>`. Examples:
+     - `literal_quote: "조용한" — set in 48pt SF Pro Display, onboarding hero`
+     - `literal_quote: "47.2-A" — sample order ID, mono on the order detail screen`
+     - `literal_quote: "회" — quantity unit in the picker`
+     - Reject abstract concepts (`"luxury"`, `"trust"`) — the literal quote is text/digits/glyphs the prototype renders.
    - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
    - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a Material/HIG default. Prose-only cues are rejected.
    - Never invent hex / font / spacing values without an image to point at. Mark uncertain extractions with `≈` and cite the source image.
+
+   **Verbatim render check** — Phase 5B is required to render the `literal_quote` string verbatim in at least one screen file under `prototype-mobile/`. The Phase 2 CHECKPOINT below verifies the field is populated; Phase 5B verifies it appears in rendered output.
 8) Commit to a BOLD aesthetic direction with mobile lens:
    - Apply the mobile design lens: one-handed usability, first 3-second impression, memorable gestures
 9) Generate `docs/design_philosophy.md`:
@@ -169,14 +176,17 @@ If the result is `true`:
        - "List items use `borderLeftWidth: 4` in `colors.accent` on the focused/active row only — no background highlight"
        - "FABs offset 16pt above the home indicator and overhang the safe area by -12pt — never centered"
        - "Bottom sheet snap points: 35% / 70% / 100% with `swipeDownEnabled` + Haptic.Light on snap"
-   - **Reference Anchors** section (from step 7.5 image-grounded research): 5 adopted cues each citing an image (path under `docs/references/` or a user-provided image URL/path), 3–5 avoided cues with reasons. If step 7.5 took Path (c) and skipped this section, omit it here too and proceed.
+   - **Reference Anchors** section (from step 7.5 image-grounded research): 2–3 strong adopted cues each citing an image (path under `docs/references/` or a user-provided image URL/path), 1 `literal_quote:` field (mandatory unless Phase 1.5 was skipped), 3–5 avoided cues with reasons. If step 7.5 took Path (c) and skipped this section, omit it here too and proceed.
    - What makes this design UNFORGETTABLE (should align with and reinforce the Signature Move).
 10) Present the design philosophy to the user and ask for approval before proceeding.
     - If rejected, iterate on the direction.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
-> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line. If Reference Anchors is present, every adopted cue MUST cite an image path under `docs/references/` or a user-provided image URL/path — NOT a generic webpage URL that was WebFetched.
-> If the Signature Move is prose-only, or Reference Anchors lacks image citations, or Reference Anchors has 0 cues without an explicit skip line: STOP and fix before proceeding.
+> Verify `docs/design_philosophy.md` exists with:
+> (a) a **Signature Move** that is numeric/token-specific (not prose-only);
+> (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line; AND
+> (c) when Reference Anchors is present, exactly **2–3** adopted cues (not 1, not 4+), each citing an image path, plus a `literal_quote:` field with a concrete word/number/glyph (NOT an adjective like "luxury"). The literal_quote may only be omitted if Phase 1.5 interview was explicitly skipped — in which case `literal_quote: (skipped — interview not run)` must appear instead of the field being absent.
+> If any of (a) / (b) / (c) fails: STOP and fix before proceeding.
 
 ### Phase 3 — Mobile Design System
 11) Generate `docs/design_system_mobile.md` reflecting the chosen aesthetic:
@@ -385,6 +395,11 @@ If the result is `true`:
     - The Signature Move must be implemented as a reusable component/hook/HOC under `src/components/` or `src/theme/`.
     - Every `.tsx` file in `src/screens/` (including the pilots) must reference that reusable Signature Move primitive at least once.
     - If any check fails: list violations, fix, and re-verify before proceeding.
+28.6) **Literal quote verbatim render check** (skip if Phase 1.5 was explicitly skipped):
+    - Read `literal_quote:` from `docs/design_philosophy.md` Reference Anchors.
+    - Grep `src/screens/*.tsx` for the literal string. The string MUST appear verbatim in at least one screen file (inside a string literal, NOT inside a comment).
+    - If absent: name the screens that would naturally host it (per the anchor's "where it appears" hint), inject the quote into that screen, and re-grep. Do not skip by widening the search.
+    - Example: `literal_quote: "47.2-A"` MUST appear as the literal characters `47.2-A` — not `47-2-A`, not interpolated from a variable, not inside `{/* */}`.
 29) **Performance check**:
     - List item components used in FlatList MUST use `React.memo`
     - Event handlers passed to memoized children MUST use `useCallback`

--- a/skills/mobile-uiux/SKILL.md.tmpl
+++ b/skills/mobile-uiux/SKILL.md.tmpl
@@ -113,10 +113,17 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
    **Anti-reference**: WebSearch for *anti-reference titles* is acceptable. Anti-cues are written from the model's own knowledge of patterns being avoided.
 
    **Synthesis** (when Path (a) or (b) ran — output goes into `docs/design_philosophy.md` "Reference Anchors"):
-   - **5 specific visual cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `OLED black #000 + #0A0A0A surface`, `SF Pro Display 34/40 + SF Mono 13`) — **source image path under `docs/references/` OR user-provided image URL/path**.
+   - **2–3 strong cues to adopt**, each as: cue (≤12 words) — exact value or token (e.g., `OLED black #000 + #0A0A0A surface`, `SF Pro Display 34/40 + SF Mono 13`) — **source image path under `docs/references/` OR user-provided image URL/path**. Strong = present in the chosen images, specific enough that no Phase 5 implementer can fall back to a Material/HIG default. Fewer-and-deeper beats more-and-shallow.
+   - **1 literal quote** (MANDATORY when Phase 1.5 interview was NOT skipped): a specific word, number, or glyph drawn from the brand or domain that MUST appear **verbatim** in the rendered prototype screens. Format: `literal_quote: "<exact string>" — <where it appears>`. Examples:
+     - `literal_quote: "조용한" — set in 48pt SF Pro Display, onboarding hero`
+     - `literal_quote: "47.2-A" — sample order ID, mono on the order detail screen`
+     - `literal_quote: "회" — quantity unit in the picker`
+     - Reject abstract concepts (`"luxury"`, `"trust"`) — the literal quote is text/digits/glyphs the prototype renders.
    - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
    - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a Material/HIG default. Prose-only cues are rejected.
    - Never invent hex / font / spacing values without an image to point at. Mark uncertain extractions with `≈` and cite the source image.
+
+   **Verbatim render check** — Phase 5B is required to render the `literal_quote` string verbatim in at least one screen file under `prototype-mobile/`. The Phase 2 CHECKPOINT below verifies the field is populated; Phase 5B verifies it appears in rendered output.
 8) Commit to a BOLD aesthetic direction with mobile lens:
    - Apply the mobile design lens: one-handed usability, first 3-second impression, memorable gestures
 9) Generate `docs/design_philosophy.md`:
@@ -133,14 +140,17 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
        - "List items use `borderLeftWidth: 4` in `colors.accent` on the focused/active row only — no background highlight"
        - "FABs offset 16pt above the home indicator and overhang the safe area by -12pt — never centered"
        - "Bottom sheet snap points: 35% / 70% / 100% with `swipeDownEnabled` + Haptic.Light on snap"
-   - **Reference Anchors** section (from step 7.5 image-grounded research): 5 adopted cues each citing an image (path under `docs/references/` or a user-provided image URL/path), 3–5 avoided cues with reasons. If step 7.5 took Path (c) and skipped this section, omit it here too and proceed.
+   - **Reference Anchors** section (from step 7.5 image-grounded research): 2–3 strong adopted cues each citing an image (path under `docs/references/` or a user-provided image URL/path), 1 `literal_quote:` field (mandatory unless Phase 1.5 was skipped), 3–5 avoided cues with reasons. If step 7.5 took Path (c) and skipped this section, omit it here too and proceed.
    - What makes this design UNFORGETTABLE (should align with and reinforce the Signature Move).
 10) Present the design philosophy to the user and ask for approval before proceeding.
     - If rejected, iterate on the direction.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
-> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line. If Reference Anchors is present, every adopted cue MUST cite an image path under `docs/references/` or a user-provided image URL/path — NOT a generic webpage URL that was WebFetched.
-> If the Signature Move is prose-only, or Reference Anchors lacks image citations, or Reference Anchors has 0 cues without an explicit skip line: STOP and fix before proceeding.
+> Verify `docs/design_philosophy.md` exists with:
+> (a) a **Signature Move** that is numeric/token-specific (not prose-only);
+> (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line; AND
+> (c) when Reference Anchors is present, exactly **2–3** adopted cues (not 1, not 4+), each citing an image path, plus a `literal_quote:` field with a concrete word/number/glyph (NOT an adjective like "luxury"). The literal_quote may only be omitted if Phase 1.5 interview was explicitly skipped — in which case `literal_quote: (skipped — interview not run)` must appear instead of the field being absent.
+> If any of (a) / (b) / (c) fails: STOP and fix before proceeding.
 
 ### Phase 3 — Mobile Design System
 11) Generate `docs/design_system_mobile.md` reflecting the chosen aesthetic:
@@ -349,6 +359,11 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
     - The Signature Move must be implemented as a reusable component/hook/HOC under `src/components/` or `src/theme/`.
     - Every `.tsx` file in `src/screens/` (including the pilots) must reference that reusable Signature Move primitive at least once.
     - If any check fails: list violations, fix, and re-verify before proceeding.
+28.6) **Literal quote verbatim render check** (skip if Phase 1.5 was explicitly skipped):
+    - Read `literal_quote:` from `docs/design_philosophy.md` Reference Anchors.
+    - Grep `src/screens/*.tsx` for the literal string. The string MUST appear verbatim in at least one screen file (inside a string literal, NOT inside a comment).
+    - If absent: name the screens that would naturally host it (per the anchor's "where it appears" hint), inject the quote into that screen, and re-grep. Do not skip by widening the search.
+    - Example: `literal_quote: "47.2-A"` MUST appear as the literal characters `47.2-A` — not `47-2-A`, not interpolated from a variable, not inside `{/* */}`.
 29) **Performance check**:
     - List item components used in FlatList MUST use `React.memo`
     - Event handlers passed to memoized children MUST use `useCallback`

--- a/skills/uiux/SKILL.md
+++ b/skills/uiux/SKILL.md
@@ -139,10 +139,17 @@ If the result is `true`:
    **Anti-reference (separate from path choice)**: WebSearch is still acceptable for *titles* of anti-references (e.g., "what makes corporate B2B SaaS dashboards generic"). Anti-cues are written from the model's own knowledge of the pattern being avoided — they are not visual extractions and do not require image grounding.
 
    **Synthesis** (when Path (a) or (b) ran successfully — output goes into `docs/design_philosophy.md` "Reference Anchors"):
-   - **5 specific visual cues to adopt**, each as a single bullet with: cue (≤12 words) — exact value or token (e.g., `#1A1A1A on #F5EFE6`, `Fraunces 96/0.92 + Inter Tight 14`) — **source image path under `docs/references/` OR the user-provided image URL**.
+   - **2–3 strong cues to adopt**, each as a single bullet with: cue (≤12 words) — exact value or token (e.g., `#1A1A1A on #F5EFE6`, `Fraunces 96/0.92 + Inter Tight 14`) — **source image path under `docs/references/` OR the user-provided image URL**. Strong = present in the chosen images, specific enough that no Phase 5 implementer can fall back to a default. Fewer-and-deeper beats more-and-shallow: 5 cues averaged out as "generic premium SaaS"; 2–3 force a direction.
+   - **1 literal quote** (MANDATORY when Phase 1.5 interview was NOT skipped): a specific word, number, or glyph drawn from the brand or domain that MUST appear **verbatim** in the rendered prototype. Format: `literal_quote: "<exact string>" — <where it appears>`. Examples:
+     - `literal_quote: "조용한" — set in 168pt Fraunces, hero headline`
+     - `literal_quote: "47.2-A" — sample order ID, shown in mono on the order detail screen`
+     - `literal_quote: "회" — quantity unit in the picker`
+     - Reject abstract concepts here (`"luxury"`, `"trust"`, `"premium"`) — the literal quote is text/digits/glyphs the prototype renders, not adjectives.
    - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
    - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a default. Prose-only cues like "warm palette" or "bold type" are rejected — re-do them with numbers/tokens.
    - Never invent a hex value or font name without an image to point at. If an extracted detail is uncertain, mark it `≈` (approximate) and leave a comment about which image it came from.
+
+   **Verbatim render check** — Phase 5B is required to render the `literal_quote` string verbatim in at least one HTML file under `prototype/screens/`. The Phase 2 CHECKPOINT below verifies the field is populated; Phase 5B verifies it actually appears in output.
 7) Commit to a BOLD aesthetic direction. Choose one and execute with precision:
    - Brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined,
      playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel,
@@ -162,14 +169,17 @@ If the result is `true`:
        - "Section dividers: `1px solid var(--accent)` with `margin-right: 12px` indent — never full-width rules"
        - "Screen titles: Fraunces 96/0.92, `letter-spacing: -0.04em`, `transform: skew(-2deg)`"
        - "All hover states: `translateY(-2px)` + `border-left: 4px solid var(--ink)` — no opacity changes"
-   - **Reference Anchors** section (from step 6.5 image-grounded research): 5 adopted cues each pointing at an image (path under `docs/references/` or a user-provided image URL/path), 3–5 avoided cues with reasons. If step 6.5 took Path (c) and skipped this section, omit it here too and proceed.
+   - **Reference Anchors** section (from step 6.5 image-grounded research): 2–3 strong adopted cues each pointing at an image (path under `docs/references/` or a user-provided image URL/path), 1 `literal_quote:` field (mandatory unless Phase 1.5 was skipped), 3–5 avoided cues with reasons. If step 6.5 took Path (c) and skipped this section, omit it here too and proceed.
    - What makes this design UNFORGETTABLE — the one thing someone will remember (should align with and reinforce the Signature Move).
 9) Present the design philosophy to the user and ask for approval before proceeding.
    - If rejected, iterate on the direction.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
-> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line. If Reference Anchors is present, every adopted cue MUST cite an image path under `docs/references/` or a user-provided image URL/path — NOT a generic webpage URL that was WebFetched.
-> If the Signature Move is prose-only, or Reference Anchors lacks image citations, or Reference Anchors has 0 cues without an explicit skip line: STOP and fix before proceeding.
+> Verify `docs/design_philosophy.md` exists with:
+> (a) a **Signature Move** that is numeric/token-specific (not prose-only);
+> (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line; AND
+> (c) when Reference Anchors is present, exactly **2–3** adopted cues (not 1, not 4+), each citing an image path, plus a `literal_quote:` field with a concrete word/number/glyph (NOT an adjective like "luxury"). The literal_quote may only be omitted if Phase 1.5 interview was explicitly skipped — in which case `literal_quote: (skipped — interview not run)` must appear instead of the field being absent.
+> If any of (a) / (b) / (c) fails: STOP and fix before proceeding.
 
 ### Phase 3 — Design System
 9) Generate `docs/design_system.md` reflecting the chosen aesthetic:
@@ -319,6 +329,11 @@ If the result is `true`:
     - `prototype/styles.css` must implement it as a reusable class or component variant.
     - Every HTML file in `prototype/screens/` (including the pilot) must apply that class/variant at least once.
     - If any check fails: list violations, fix, and re-verify before proceeding.
+17.6) **Literal quote verbatim render check** (skip if Phase 1.5 was explicitly skipped):
+    - Read `literal_quote:` from `docs/design_philosophy.md` Reference Anchors.
+    - Grep `prototype/screens/*.html` for the literal string. The string MUST appear verbatim in at least one screen's rendered output.
+    - If absent: name the screens that would naturally host it (per the anchor's "where it appears" hint), inject the quote into that screen's HTML, and re-grep. Do not skip this check by widening the search (no substring matches, no partial matches).
+    - Example: `literal_quote: "47.2-A"` MUST appear as the literal characters `47.2-A` in at least one screen file — not `47-2-A`, not `47.2A`, not in a comment.
 18) **PRD feature cross-check**:
     - Every feature in the PRD (F1, F2, ... including P2) MUST appear in wireframes and/or interactions
     - List any gaps and add missing features (P2 features as "deferred" notes)

--- a/skills/uiux/SKILL.md.tmpl
+++ b/skills/uiux/SKILL.md.tmpl
@@ -103,10 +103,17 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
    **Anti-reference (separate from path choice)**: WebSearch is still acceptable for *titles* of anti-references (e.g., "what makes corporate B2B SaaS dashboards generic"). Anti-cues are written from the model's own knowledge of the pattern being avoided — they are not visual extractions and do not require image grounding.
 
    **Synthesis** (when Path (a) or (b) ran successfully — output goes into `docs/design_philosophy.md` "Reference Anchors"):
-   - **5 specific visual cues to adopt**, each as a single bullet with: cue (≤12 words) — exact value or token (e.g., `#1A1A1A on #F5EFE6`, `Fraunces 96/0.92 + Inter Tight 14`) — **source image path under `docs/references/` OR the user-provided image URL**.
+   - **2–3 strong cues to adopt**, each as a single bullet with: cue (≤12 words) — exact value or token (e.g., `#1A1A1A on #F5EFE6`, `Fraunces 96/0.92 + Inter Tight 14`) — **source image path under `docs/references/` OR the user-provided image URL**. Strong = present in the chosen images, specific enough that no Phase 5 implementer can fall back to a default. Fewer-and-deeper beats more-and-shallow: 5 cues averaged out as "generic premium SaaS"; 2–3 force a direction.
+   - **1 literal quote** (MANDATORY when Phase 1.5 interview was NOT skipped): a specific word, number, or glyph drawn from the brand or domain that MUST appear **verbatim** in the rendered prototype. Format: `literal_quote: "<exact string>" — <where it appears>`. Examples:
+     - `literal_quote: "조용한" — set in 168pt Fraunces, hero headline`
+     - `literal_quote: "47.2-A" — sample order ID, shown in mono on the order detail screen`
+     - `literal_quote: "회" — quantity unit in the picker`
+     - Reject abstract concepts here (`"luxury"`, `"trust"`, `"premium"`) — the literal quote is text/digits/glyphs the prototype renders, not adjectives.
    - **3–5 cues to explicitly avoid**, each with one-line reason tied to the anti-reference.
    - Each adopted cue must be specific enough that a Phase 5 implementer cannot fall back to a default. Prose-only cues like "warm palette" or "bold type" are rejected — re-do them with numbers/tokens.
    - Never invent a hex value or font name without an image to point at. If an extracted detail is uncertain, mark it `≈` (approximate) and leave a comment about which image it came from.
+
+   **Verbatim render check** — Phase 5B is required to render the `literal_quote` string verbatim in at least one HTML file under `prototype/screens/`. The Phase 2 CHECKPOINT below verifies the field is populated; Phase 5B verifies it actually appears in output.
 7) Commit to a BOLD aesthetic direction. Choose one and execute with precision:
    - Brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined,
      playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel,
@@ -126,14 +133,17 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
        - "Section dividers: `1px solid var(--accent)` with `margin-right: 12px` indent — never full-width rules"
        - "Screen titles: Fraunces 96/0.92, `letter-spacing: -0.04em`, `transform: skew(-2deg)`"
        - "All hover states: `translateY(-2px)` + `border-left: 4px solid var(--ink)` — no opacity changes"
-   - **Reference Anchors** section (from step 6.5 image-grounded research): 5 adopted cues each pointing at an image (path under `docs/references/` or a user-provided image URL/path), 3–5 avoided cues with reasons. If step 6.5 took Path (c) and skipped this section, omit it here too and proceed.
+   - **Reference Anchors** section (from step 6.5 image-grounded research): 2–3 strong adopted cues each pointing at an image (path under `docs/references/` or a user-provided image URL/path), 1 `literal_quote:` field (mandatory unless Phase 1.5 was skipped), 3–5 avoided cues with reasons. If step 6.5 took Path (c) and skipped this section, omit it here too and proceed.
    - What makes this design UNFORGETTABLE — the one thing someone will remember (should align with and reinforce the Signature Move).
 9) Present the design philosophy to the user and ask for approval before proceeding.
    - If rejected, iterate on the direction.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
-> Verify `docs/design_philosophy.md` exists with (a) a **Signature Move** that is numeric/token-specific (not prose-only), and (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line. If Reference Anchors is present, every adopted cue MUST cite an image path under `docs/references/` or a user-provided image URL/path — NOT a generic webpage URL that was WebFetched.
-> If the Signature Move is prose-only, or Reference Anchors lacks image citations, or Reference Anchors has 0 cues without an explicit skip line: STOP and fix before proceeding.
+> Verify `docs/design_philosophy.md` exists with:
+> (a) a **Signature Move** that is numeric/token-specific (not prose-only);
+> (b) either a populated **Reference Anchors** section OR an explicit "Reference Anchors skipped (no image input)" line; AND
+> (c) when Reference Anchors is present, exactly **2–3** adopted cues (not 1, not 4+), each citing an image path, plus a `literal_quote:` field with a concrete word/number/glyph (NOT an adjective like "luxury"). The literal_quote may only be omitted if Phase 1.5 interview was explicitly skipped — in which case `literal_quote: (skipped — interview not run)` must appear instead of the field being absent.
+> If any of (a) / (b) / (c) fails: STOP and fix before proceeding.
 
 ### Phase 3 — Design System
 9) Generate `docs/design_system.md` reflecting the chosen aesthetic:
@@ -283,6 +293,11 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, WebSearch
     - `prototype/styles.css` must implement it as a reusable class or component variant.
     - Every HTML file in `prototype/screens/` (including the pilot) must apply that class/variant at least once.
     - If any check fails: list violations, fix, and re-verify before proceeding.
+17.6) **Literal quote verbatim render check** (skip if Phase 1.5 was explicitly skipped):
+    - Read `literal_quote:` from `docs/design_philosophy.md` Reference Anchors.
+    - Grep `prototype/screens/*.html` for the literal string. The string MUST appear verbatim in at least one screen's rendered output.
+    - If absent: name the screens that would naturally host it (per the anchor's "where it appears" hint), inject the quote into that screen's HTML, and re-grep. Do not skip this check by widening the search (no substring matches, no partial matches).
+    - Example: `literal_quote: "47.2-A"` MUST appear as the literal characters `47.2-A` in at least one screen file — not `47-2-A`, not `47.2A`, not in a comment.
 18) **PRD feature cross-check**:
     - Every feature in the PRD (F1, F2, ... including P2) MUST appear in wireframes and/or interactions
     - List any gaps and add missing features (P2 features as "deferred" notes)

--- a/tests/test_reference_anchor_tuning.py
+++ b/tests/test_reference_anchor_tuning.py
@@ -1,0 +1,121 @@
+"""Tests for ISSUE-012: Reference Anchor tuning (2-3 cues + 1 literal quote).
+
+These tests verify the three uiux skill templates declare:
+- "2–3 strong cues" (not "5 specific visual cues")
+- A `literal_quote:` field is mandated when Phase 1.5 is not skipped
+- The Phase 5.x prototype-verification phase grep-checks for the literal
+  quote verbatim in rendered output
+- The Phase 2 CHECKPOINT requires the literal_quote field
+
+The tests parse the markdown — they do NOT run /uiux.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+UIUX_TMPL_PATHS = [
+    Path("skills/uiux/SKILL.md.tmpl"),
+    Path("skills/mobile-uiux/SKILL.md.tmpl"),
+    Path("skills/desktop-uiux/SKILL.md.tmpl"),
+]
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"missing template: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+class TestCueCountReduced:
+    """Every uiux template declares 2–3 adopted cues, not the old 5."""
+
+    def test_no_old_five_cue_phrasing(self):
+        offenders: list[tuple[str, int, str]] = []
+        for tmpl in UIUX_TMPL_PATHS:
+            text = _read(tmpl)
+            for line_no, line in enumerate(text.splitlines(), 1):
+                # The OLD shape was "5 specific visual cues to adopt" /
+                # "5 adopted cues". Any line that still uses the count "5"
+                # in the context of "cues to adopt" is a regression.
+                if re.search(r"\b5\s+(?:specific\s+visual\s+)?cues?\s+to\s+adopt", line, re.IGNORECASE):
+                    offenders.append((str(tmpl), line_no, line.strip()))
+                if re.search(r"\b5\s+adopted\s+cues?\b", line, re.IGNORECASE):
+                    offenders.append((str(tmpl), line_no, line.strip()))
+        assert not offenders, (
+            "Old 5-cue phrasing resurfaced (ISSUE-012 reduced to 2–3):\n"
+            + "\n".join(f"  {p}:{n}: {ln}" for p, n, ln in offenders)
+        )
+
+    def test_two_to_three_phrasing_present(self):
+        for tmpl in UIUX_TMPL_PATHS:
+            text = _read(tmpl)
+            assert re.search(r"\b2[–\-]3\s+strong\s+(?:adopted\s+)?cues?", text), (
+                f"{tmpl} does not declare 2–3 strong adopted cues."
+            )
+
+
+class TestLiteralQuoteMandate:
+    """Every uiux template introduces the literal_quote field and its render check."""
+
+    def test_literal_quote_field_introduced(self):
+        for tmpl in UIUX_TMPL_PATHS:
+            text = _read(tmpl)
+            assert "literal_quote:" in text, (
+                f"{tmpl} does not mention `literal_quote:` field."
+            )
+            assert "verbatim" in text.lower(), (
+                f"{tmpl} does not mention verbatim rendering of the literal quote."
+            )
+
+    def test_phase_2_checkpoint_requires_literal_quote(self):
+        """The Phase 2 CHECKPOINT block must require the literal_quote field."""
+        for tmpl in UIUX_TMPL_PATHS:
+            text = _read(tmpl)
+            # Find the Phase 2 CHECKPOINT block (the one near the end of Phase 2).
+            # It is the block that mentions design_philosophy.md.
+            checkpoint_blocks = re.findall(
+                r"^> \*\*CHECKPOINT.*?(?=\n###|\n\Z)",
+                text,
+                re.MULTILINE | re.DOTALL,
+            )
+            phase2_checkpoint = None
+            for block in checkpoint_blocks:
+                if "design_philosophy.md" in block:
+                    phase2_checkpoint = block
+                    break
+            assert phase2_checkpoint is not None, (
+                f"{tmpl}: no Phase 2 CHECKPOINT mentioning design_philosophy.md found."
+            )
+            assert "literal_quote" in phase2_checkpoint, (
+                f"{tmpl} Phase 2 CHECKPOINT does not require literal_quote:\n"
+                f"{phase2_checkpoint[:300]}..."
+            )
+            assert re.search(r"2[–\-]3", phase2_checkpoint), (
+                f"{tmpl} Phase 2 CHECKPOINT does not enforce 2–3 cues:\n"
+                f"{phase2_checkpoint[:300]}..."
+            )
+
+    def test_phase_5_verbatim_render_check_present(self):
+        """Phase 5.x has a step that grep-checks for the literal_quote verbatim."""
+        for tmpl in UIUX_TMPL_PATHS:
+            text = _read(tmpl)
+            assert re.search(
+                r"Literal quote verbatim render check",
+                text,
+                re.IGNORECASE,
+            ), (
+                f"{tmpl} does not declare a 'Literal quote verbatim render check' "
+                "step in Phase 5.x."
+            )
+
+    def test_literal_quote_rejects_abstract_words(self):
+        """Each template tells the model to reject abstract concepts as the quote."""
+        for tmpl in UIUX_TMPL_PATHS:
+            text = _read(tmpl)
+            # The instruction should explicitly call out adjectives/concepts
+            # like "luxury" or "trust" as invalid.
+            assert "luxury" in text.lower() or "trust" in text.lower(), (
+                f"{tmpl} does not exemplify rejected abstract quotes "
+                "(literal_quote must be concrete text/digits/glyphs)."
+            )


### PR DESCRIPTION
## Summary
Builds on ISSUE-011's image-grounded references with two changes that sharpen product specificity at Phase 2:

1. **5 → 2-3 adopted cues**. 5 cues created averaging pressure (model picks safe generic cues; result degrades to "generic premium SaaS"). Fewer-and-deeper forces specificity per cue.
2. **New mandatory \`literal_quote:\` field** — a specific word/number/glyph/shortcut from the brand or domain that MUST render verbatim in the prototype. Abstract concepts ("luxury", "trust") are rejected.

Examples per platform:
- web: \`literal_quote: "조용한" — 168pt Fraunces, hero\`
- mobile: \`literal_quote: "47.2-A" — sample order ID, mono on order detail\`
- desktop: \`literal_quote: "⌘K" — command palette trigger in sidebar\`

Phase 2 CHECKPOINT enforces 2-3 cues + literal_quote presence. Phase 5.x prototype verification grep-checks the literal string appears verbatim (exact-string match, no substring).

## Test plan
- [x] \`pytest tests/test_reference_anchor_tuning.py\` — 6 passed
- [x] \`pytest tests/test_uiux_reference_fabrication_guard.py\` — 4 passed (no regression on ISSUE-011 guard)
- [x] \`scripts/gen_skills.py --dry-run\` — all SKILL.md fresh
- [x] \`validate_issues.py issues.md\` — 13/13 pass
- [x] \`validate_spec.py docs/specs/\` — 5/5 SPECs pass
- [ ] Manual: run \`/uiux\` end-to-end on a real project; verify the literal_quote field is filled and renders verbatim in the prototype

## Notes
- Depends on ISSUE-011 (image-grounded references) — already merged.
- Existing \`design_philosophy.md\` files keep their old anchors; new runs land the new format.

Closes ISSUE-012

🤖 Generated with [Claude Code](https://claude.com/claude-code)