### PR TITLE
docs(readme): sync counts, positioning, packs section, team-scale usage (ISSUE-005)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,22 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11%2B-3776AB.svg)](https://python.org)
-[![Tests](https://img.shields.io/badge/Tests-530%20passing-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/Tests-917%20passing-brightgreen.svg)]()
 
-Turn a PRD into shipped code. 33 AI agents and 22 skills that handle the entire development lifecycle — from brainstorming to code review to deployment — so you can focus on what to build, not how.
+Turn a PRD into shipped code. **33 engineering agents + 23 skills** (default install) handle the entire development lifecycle — from PRD to code review to deployment — so you can focus on what to build, not how. An optional **sales pack** (5 agents + 5 skills, opt-in via `--pack=sales`) covers account / discovery / proposal workflows for teams sharing a repo with engineering.
 
 ## Why claude-kit?
 
+**Positioning: trustworthy code in collaboration → AI dev team control plane.** The kit's bet is that AI productivity is bottlenecked not by the model but by what surrounds it — concurrency, state, guardrails, decision capture, learning. Adding more agents doesn't close that gap; structuring the work does.
+
 Claude Code is powerful on its own, but without structure it produces inconsistent results — skipped tests, forgotten reviews, PRs that drift from requirements. claude-kit solves this by giving Claude Code **a repeatable process**:
 
-- **Structured pipeline**: Every issue goes through implement → review → ship. No shortcuts, no skipped phases.
-- **Specialized agents**: Instead of one generalist prompt, 32 agents each handle what they're best at — an architect designs the system, a reviewer audits security, a QA designer writes test plans.
+- **Structured pipeline**: Every issue goes through spec (when required) → implement → review → ship. No shortcuts, no skipped phases.
+- **Specialized agents**: Instead of one generalist prompt, 33 engineering agents each handle what they're best at — an architect designs the system, a reviewer audits security, a QA designer writes test plans, a design-auditor critiques the system, a separate ui-reviewer critiques the implementation.
+- **Decision capture**: Non-trivial issues require a SPEC (`/spec` → `docs/specs/SPEC-NNN.md`) — Problem / Options ≥2 / Trade-offs / Decision / Rollback. Sprint mode auto-runs it; non-sprint mode HOLDs for review.
 - **Automatic feedback loops**: Review findings create follow-up issues. Test failures trigger root-cause analysis. Shipped code gets test gap detection. Nothing falls through the cracks.
 - **Resumable state**: Sprint progress is checkpointed to `sprint_state.md`. Crash or timeout? Just re-run `/sprint` to pick up where you left off.
-- **Zero configuration**: Install as a git submodule, run one script, and all agents/skills/hooks are ready.
+- **Zero configuration**: Install as a git submodule, run one script, and all agents/skills/hooks are ready. Pack opt-in via a single flag.
 
 In short: claude-kit turns Claude Code from a smart assistant into a **development team that follows engineering best practices**.
 
@@ -32,7 +35,8 @@ claude-kit takes a PRD (Product Requirements Document) as input and orchestrates
 
 ### 1. Build a product from scratch
 ```
-/brainstorm → /bizanalysis → /prd → /kickoff → /uiux → /sprint
+/prd → /kickoff → /uiux → /sprint
+# (optional pre-PRD: /brainstorm → /bizanalysis → /prd)
 ```
 Start with an idea, validate it, write a PRD, generate planning docs, design the UI, and let the team-lead auto-implement everything.
 
@@ -83,7 +87,8 @@ Auto-detects that this spans multiple screens/modules, estimates issue count, up
 
 **New project:**
 ```
-/brainstorm → /bizanalysis → /prd → /kickoff → /uiux → /sprint
+/prd → /kickoff → /uiux → /sprint
+# (optional pre-PRD: /brainstorm → /bizanalysis → /prd)
 ```
 
 **Existing codebase (no PRD):**
@@ -101,7 +106,7 @@ Auto-detects that this spans multiple screens/modules, estimates issue count, up
 /issue "feature description" → /sprint (or /implement per issue)
 ```
 
-> `/brainstorm` and `/bizanalysis` are optional. If your idea is clear, start from `/prd`.
+> **Optional pre-PRD**: `/brainstorm` (Socratic exploration) and `/bizanalysis` (market + SWOT) are stand-alone primitives, not part of the default flow. If your idea is clear, start from `/prd`. These exist for the case where you genuinely don't know what to build yet.
 > `/uiux`, `/mobile-uiux`, and `/desktop-uiux` are optional for UI projects. Backend/CLI projects go directly from `/kickoff` to `/sprint`.
 > `/sprint` auto-orchestrates multiple issues. For a single issue, use `/implement` directly.
 > `/scan` is for existing codebases without a PRD. It reverse-engineers planning docs from code.
@@ -129,16 +134,31 @@ review_lessons.md → patterns with Frequency ≥ 3 + Critical/High severity
 
 Standalone skills (`/testgen`, `/diagnose`, `/refactor`) register their work in `issues.md` when it exists, so team-lead can track all work in `sprint_state.md`.
 
+### Packs
+
+The default install ships the **core** layer — engineering agents, design pack (uiux / mobile-uiux / desktop-uiux), and safety guardrails. Domain-specific workflows live in opt-in **packs** that depend on core.
+
+| Pack | What it adds | Install command |
+|---|---|---|
+| **core** (default) | 33 engineering agents + 23 skills | `bash .claude-kit/scripts/install_project.sh` |
+| **sales** | 5 sales agents + 5 sales skills + 7 sales templates | `bash .claude-kit/scripts/install_project.sh --pack=sales` |
+| (every declared pack) | core + every pack under `packs/` | `bash .claude-kit/scripts/install_project.sh --pack=all` |
+
+Rules:
+- **Packs are additive on top of core, never substitutes.** Every pack's `manifest.yaml` declares `depends_on: [core]`. The installer enforces this — there is no "pack-only" install.
+- Pack entries (agents / skills) live alongside core's in `.claude/agents/` and `.claude/skills/` via per-entry symlinks. Re-running the installer with a different `--pack` set is the supported way to add / remove packs.
+- Pack `settings.snippet.json` (if declared) merges after core's, with pack values winning on key collision.
+
+See `packs/README.md` for the manifest schema and rules for contributing new packs.
+
 ### Decision Tree — Which skill should I use?
 
 ```
 START
  │
- ├─ Have an idea but direction is unclear?
- │   └─ YES → /brainstorm → Need business validation? → /bizanalysis → /prd
- │
  ├─ No PRD yet?
  │   └─ YES → /prd
+ │   └─ (optional pre-PRD: direction unclear → /brainstorm → /bizanalysis → /prd)
  │
  ├─ PRD exists but no planning docs?
  │   └─ YES → /kickoff PRD.md
@@ -233,10 +253,22 @@ bash .claude-kit/scripts/install_user.sh
 
 ### 3. Install into project
 
-Copies agents, skills, hooks, and settings into the project's `.claude/` directory.
+Symlinks core agents, skills, hooks, and settings into the project's `.claude/` directory. Default install is **core only**:
 
 ```bash
 bash .claude-kit/scripts/install_project.sh
+```
+
+To include the sales pack (account-research / discovery / proposal / meeting-capture / follow-up):
+
+```bash
+bash .claude-kit/scripts/install_project.sh --pack=sales
+```
+
+To include every declared pack:
+
+```bash
+bash .claude-kit/scripts/install_project.sh --pack=all
 ```
 
 After installation:
@@ -244,13 +276,15 @@ After installation:
 ```
 your-service-repo/
 ├── .claude/
-│   ├── agents/          # 32 agent definitions
-│   ├── skills/          # 21 skills
+│   ├── agents/          # 33 core agents (or +5 if --pack=sales)
+│   ├── skills/          # 23 core skills (or +5 if --pack=sales)
 │   ├── hooks/           # agent_state.py (agent state tracking)
 │   └── settings.json    # Status line + hook config (auto-merged)
-├── .claude-kit/         # submodule (source)
+├── .claude-kit/         # submodule (source — contains packs/ subtree too)
 └── ...
 ```
+
+> Re-running the installer with a different `--pack` set is destructive of the pack entries from the previous install (the install set IS the active install). Symlinks are per-entry so core + selected packs coexist in the same `.claude/agents/` and `.claude/skills/`.
 
 ### 4. Verify gh authentication
 
@@ -259,6 +293,59 @@ gh auth status
 ```
 
 If not authenticated, run `gh auth login`.
+
+## Team-scale usage
+
+The kit assumes **the repo IS the team boundary**. Two adoption patterns cover the common shapes — and there is deliberately no separate "team layer."
+
+### Pattern (a) — Monorepo (engineering or sales)
+
+The common pattern. One repo holds all team work; the kit installs once at the root.
+
+- **Engineering team**: services live under `services/<name>/` subdirectories. Each service worktree is created from the repo root via `scripts/worktree.sh`. Shared state (`issues.md`, `STATUS.md`, `sprint_state.md`) sits at the root.
+- **Sales team**: accounts live under `accounts/<company>/` subdirectories. Cross-account patterns accumulate in repo-root `docs/sales_lessons.md`. Walk-up resolution via `scripts/find_shared.sh` finds shared sales-pack files (e.g., `sales_email_persona.md`) from inside any account directory.
+
+```
+~/work/my-team/                       # team boundary == repo boundary
+├── .claude-kit/                      # submodule
+├── .claude/                          # installed (--pack=sales for sales)
+├── issues.md, STATUS.md
+├── docs/                             # shared knowledge
+├── services/auth/                    # (engineering) one git checkout
+├── services/gateway/                 # ...
+│   └── ...
+# OR
+├── accounts/customer-a/              # (sales) one account
+├── accounts/customer-b/              # ...
+```
+
+### Pattern (b) — Virtual monorepo wrapper (polyrepo teams)
+
+When services genuinely cannot be in one repo (independent release cadence, vendor isolation, etc.), wrap them. A top-level **wrapper directory** is itself a git repo holding the `.claude-kit/` submodule and shared kit state at its root; each independent service repo lives as an immediate subdirectory and is gitignored from the wrapper.
+
+```
+~/work/my-team/                       # wrapper = git repo
+├── .git/
+├── .gitignore                        # auth-service/, gateway-service/, ...
+├── .claude-kit/                      # submodule
+├── .claude/                          # installed at wrapper root
+├── issues.md, STATUS.md, sprint_state.md
+├── docs/
+├── auth-service/                     # independent git repo (gitignored)
+├── gateway-service/                  # independent git repo (gitignored)
+└── payments-service/                 # independent git repo (gitignored)
+```
+
+Per-service work routes to the right subdirectory; kit state stays at the wrapper root. Code-level support for this layout (Target-Service field, `worktree.sh --service` flag, wrapper-root detection in `flock_edit.sh`) is tracked as ISSUE-008 — gated on telemetry signal that polyrepo friction is real before we ship the helpers.
+
+### Why no separate "team layer"
+
+A separate layer would add concepts (a new manifest type, a new install scope) without adding capability:
+- **Sales team accumulation** already works via `accounts/<company>/` subdirectories in a sales-pack install. The repo's accounts directory IS the team asset store.
+- **Cross-team installation** uses the existing `--pack` flag (one repo can install core + sales together).
+- **Polyrepo collaboration** uses the wrapper pattern above. The wrapper directory IS the team boundary.
+
+Adding a "team layer" would raise the onboarding cost (more concepts to learn, more install steps) for zero new capability over what the existing core + pack + wrapper model already provides. **This decision is intentional, not a transitional state.** Documented here so contributors don't re-propose it.
 
 ## Usage
 
@@ -459,7 +546,7 @@ Session-scoped safety modes for working in sensitive environments or scoping edi
 
 ## Agents
 
-33 specialized agents with optimized model assignments (opus for judgment/creativity, sonnet for structured extraction):
+**33 core engineering agents** (default install) with optimized model assignments — opus for judgment/creativity, sonnet for structured extraction. **The sales pack adds 5 more** (`account-researcher`, `champion-mapper`, `discovery-coach`, `meeting-synthesizer`, `proposal-writer`) when installed with `--pack=sales`. See [Packs](#packs) for opt-in install.
 
 | Agent | Model | Role | Tools |
 |-------|-------|------|-------|
@@ -497,12 +584,29 @@ Session-scoped safety modes for working in sensitive environments or scoping edi
 | `scan-qa-designer` | sonnet | Assess existing test coverage and identify gaps | Read, Glob, Grep, Write, Edit |
 | `scan-planner` | opus | Generate improvement issues from scan observations | Read, Glob, Grep, Write, Edit |
 
+## Roadmap
+
+The next layer the kit is building: **AI dev team control plane** — telemetry → eval → cumulative learning memory. Each issue ships as its own SPEC + PR; no dates committed.
+
+- **ISSUE-001 — Run telemetry**: every agent invocation, tool call, and phase emits a JSONL trace event so lead time, retry rate, and finding density can be measured without touching agent prompts.
+- **ISSUE-002 — Workflow eval gate**: LLM-as-judge scoring of `review_notes.md` against the PR diff. Non-blocking advisory at first; data feeds future thresholds.
+- **ISSUE-003 — Cumulative learning memory**: promote `docs/review_lessons.md` to a structured pattern store (`.claude/memory/patterns.jsonl` + `docs/decision_log.md`). The `reviewer` and `planner` agents consume top-N patterns as preamble context.
+- **ISSUE-008 — Virtual monorepo wrapper code support**: per-service routing helpers + wrapper-root detection. Gated on telemetry signal (ISSUE-001) that polyrepo teams actually hit friction.
+
+Recently shipped (Cluster C + D this session): `/spec` skill + Spec-Required metadata (ISSUE-006), `/implement` Phase 0 spec gate (ISSUE-007), Pilot Gate hardening — neutral observation + separate-context critic + specificity + auto-cycle (ISSUE-010), Kill WebFetch reference fabrication (ISSUE-011), Reference Anchor tuning to 2–3 cues + literal_quote (ISSUE-012), `design-auditor` / `ui-reviewer` scope split (ISSUE-013). See `docs/specs/` for each SPEC.
+
 ## Project Structure
 
 ```
 claude-dev-kit/
-├── agents/                  # Agent role definitions (33)
-├── skills/                  # Workflow skills (22)
+├── agents/                  # Core engineering agents (33)
+├── skills/                  # Core engineering / design / safety skills (23)
+├── packs/                   # Opt-in domain packs
+│   └── sales/               # Sales pack (5 agents + 5 skills + 7 templates)
+│       ├── agents/
+│       ├── skills/
+│       ├── templates/
+│       └── manifest.yaml
 │   ├── brainstorm/SKILL.md
 │   ├── bizanalysis/SKILL.md
 │   ├── prd/SKILL.md
@@ -525,7 +629,7 @@ claude-dev-kit/
 │   ├── careful/SKILL.md     # Safety guardrail: destructive command warnings
 │   ├── freeze/SKILL.md      # Safety guardrail: edit boundary enforcement
 │   └── guard/SKILL.md       # Safety guardrail: careful + freeze combined
-├── templates/               # Document templates (24)
+├── templates/               # Core document templates (26)
 ├── project/                 # Files installed into target project
 │   └── .claude/
 │       ├── hooks/agent_state.py

--- a/docs/specs/SPEC-005.md
+++ b/docs/specs/SPEC-005.md
@@ -1,0 +1,84 @@
+# SPEC-005: README sync — counts, positioning, packs section, team-scale usage
+
+> Linked Issue: ISSUE-005
+> Status: `accepted`
+> Date: 2026-06-14
+> Author: claude-dev-kit
+
+## Problem
+
+The README hasn't been updated since the pack split. It still claims "33 AI agents and 22 skills," routes `/brainstorm` and `/bizanalysis` as part of the default workflow (now demoted to optional pre-PRD), shows the install command without the `--pack` flag, and has no Packs section, no Team-scale usage guidance, no Roadmap referencing the control-plane work. Reading the README as a new user today produces a wrong mental model of the kit.
+
+## Context
+
+- After ISSUE-004 + ISSUE-009: core = 33 agents + 23 skills (top-level); sales pack (opt-in) = 5 agents + 5 skills. Install command supports `--pack=core|sales|all`.
+- The kit's positioning has sharpened to "trustworthy code in collaboration → AI dev team control plane." The README should make that the dominant frame.
+- Six SPECs (006, 007, 010, 011, 012, 013) have already landed. ISSUE-001/002/003 (telemetry → eval → memory) and 008 (polyrepo) remain. The Roadmap section should reference them by ID.
+- Team-scale usage was deferred from this issue's original scope but the discussion in conversation 2026-05-30 produced two patterns (monorepo + virtual monorepo wrapper) and an explicit rationale for NOT adding a separate "team layer." This SPEC captures the rationale so contributors don't re-propose it.
+
+## Options
+
+### Option A: Surgical edits in place (preserve structure)
+- **Approach**: Update counts in 5 known spots (tagline, "Why" bullet, Project Structure, Agents section header, Installation post-install layout). Add three new sections (Packs, Team-scale usage, Roadmap) in coherent locations. Demote brainstorm/bizanalysis to a sub-note in workflow + decision tree. Add `--pack` flag to Installation. Replace the agent table's count claim with a core-count + a note pointing at Packs. Keep all skill descriptions intact.
+- **Pros**:
+  - Existing Workflow / Skill Orchestration / Decision Tree sections all work — only counts and a few entries need adjustment.
+  - Reviewers can diff narrowly against today's README.
+- **Cons**:
+  - Three new sections grow the README ~80 lines.
+- **Trade-off**: +3 new sections (~80 lines), +1 demotion sub-note (~3 lines), -5 stale count references (replaced); +0 structural rewrites; 0 breakage to existing internal links.
+
+### Option B: Rewrite the README from scratch with new positioning as the spine
+- **Approach**: Rebuild around the "control plane" framing.
+- **Pros**:
+  - Cleanest narrative.
+- **Cons**:
+  - Throws away years of careful sectioning (Decision Tree, Skill Orchestration, Workflow examples). Reviewer cognitive load is high. Risk of regressing in-doc references that other docs link to.
+- **Trade-off**: vs A, +1 cohesive rewrite, -100% reviewer ability to spot drift, -1 link stability with external consumers of internal anchors.
+
+### Option C: Defer the team-scale usage section to its own PR (just sync counts + Packs)
+- **Approach**: Land counts + Packs section + Roadmap now, leave team-scale guidance for a follow-up.
+- **Pros**:
+  - Smaller PR.
+- **Cons**:
+  - Team-scale usage is the section future contributors most need to *not* re-propose "add a team layer." Delaying it lets the gap persist.
+- **Trade-off**: vs A, -1 section (~30 lines); +1 risk that contributors propose a redundant team layer in the interim.
+
+## Decision
+
+**Chosen: Option A.**
+
+The trade-off "+3 new sections (~80 lines), -5 stale count references" wins because the existing README structure is already in production use, internal anchors are likely referenced from contributor docs, and the new sections (Packs / Team-scale / Roadmap) each have a natural home in the existing flow. Option B risks more than it gains; Option C leaves the most-asked-for guidance unwritten.
+
+## Trade-offs Accepted
+
+- Counts are quoted in multiple places (tagline, Project Structure, Agents section header). When the kit grows, all three must be updated together. The README is unlikely to be auto-checked against `ls agents/ skills/ packs/sales/agents/`, so contributor discipline is required.
+- The "/brainstorm" / "/bizanalysis" entries stay in the skill table but get an "optional pre-PRD" framing. We do not delete them — they remain valid skills.
+- The Roadmap references issue IDs (not dates). When ISSUE-001/002/003/008 land, the Roadmap section needs a follow-up update — but counts-only updates without rewriting the Roadmap narrative.
+- The Team-scale usage section explains why a separate "team layer" was NOT added. This is a defensive section — future contributors reading the kit should see this rationale before proposing the layer again.
+
+## Migration
+
+1. Edit `README.md`:
+   - Tagline + "Why claude-kit?" intro: refresh positioning ("trustworthy code in collaboration → AI dev team control plane"), update counts to 33/23 + (sales pack: 5/5 opt-in).
+   - Workflow + Decision Tree: demote `/brainstorm` and `/bizanalysis` to "optional pre-PRD" sub-note.
+   - New section **Packs**: explain core (default) vs sales (opt-in via `--pack=sales`); how additional packs work; link to `packs/README.md`.
+   - Installation: update post-install directory diagram to show 33 agents + 23 skills + optional `--pack` examples (`--pack=sales`, `--pack=all`).
+   - New section **Team-scale usage** (after Installation):
+     - Pattern (a) Monorepo (engineering + sales common pattern).
+     - Pattern (b) Virtual monorepo wrapper (polyrepo team solution).
+     - **Why no separate "team layer"** rationale — short paragraph stating the existing pack model + the wrapper directory cover both adoption shapes without adding a concept.
+   - Agents section header: update count to "33 engineering agents (default install). Sales pack adds 5 more — see Packs."
+   - Project Structure: update post-install layout to current counts; reflect `packs/sales/` subtree.
+   - New section **Roadmap** (near the end, before Project Structure or after Agents): 3 bullets — telemetry (ISSUE-001), eval (ISSUE-002), cumulative memory (ISSUE-003) — each one sentence, no dates. Mention that spec / pilot gate / agent boundary / WebFetch fix already shipped (link by issue ID).
+2. Run a manual link check (`grep -n '\.md' README.md`) and confirm no removed anchors.
+3. No code changes. README is documentation-only.
+
+## Rollback
+
+`git revert` the README commit. The kit continues to work — README content is purely informational. No data or code dependencies on README. Rollback time: < 1 minute.
+
+## Open Questions
+
+- [ ] Should the README counts be auto-checked against the filesystem at CI time (e.g., a tiny script that compares quoted "33 agents" to `ls agents | wc -l`)? — owner: process, by: after a 3rd kit growth causes a stale count.
+- [ ] Should the "Team-scale usage" section grow examples (a real monorepo layout + a real wrapper layout in code blocks)? — owner: docs, by: after the first contributor question about team adoption.
+- [ ] Should the Roadmap section move to its own document (`docs/roadmap.md`) once it grows past 3–5 items? — owner: docs, by: when 6+ open ISSUEs are referenced.

--- a/issues.md
+++ b/issues.md
@@ -23,7 +23,6 @@
 - [ ] ISSUE-001: Run telemetry MVP — JSONL trace from agent_state hook _(track: platform, P1, 1.5d)_
 - [ ] ISSUE-002: Workflow eval gate MVP — LLM-as-judge for review_notes quality _(track: platform, P1, 1.5d)_
 - [ ] ISSUE-003: Cumulative learning memory MVP — promote review_lessons to structured store _(track: platform, P1, 1.5d)_
-- [ ] ISSUE-005: README sync — reflect counts + positioning + post-sales-boundary layout + team-scale usage _(track: platform, P1, 1d)_
 - [ ] ISSUE-008: Virtual monorepo wrapper — polyrepo team support _(track: platform, P2, 1.5d)_
 
 ### Doing
@@ -32,6 +31,7 @@
 
 ### Done
 - [x] ISSUE-004: Sales pack file move + manifest schema _(track: platform, P1, 1d)_
+- [x] ISSUE-005: README sync — reflect counts + positioning + post-sales-boundary layout + team-scale usage _(track: platform, P1, 1d)_
 - [x] ISSUE-006: /spec skill — RFC pattern + Spec-Required metadata + non-sprint HOLD gate _(track: platform, P1, 1.5d)_
 - [x] ISSUE-007: /implement spec gate — sprint auto-run + non-sprint HOLD + signal detection _(track: platform, P1, 1d)_
 - [x] ISSUE-009: Install script --pack flag + merge_settings + tests _(track: platform, P1, 1.5d)_
@@ -288,10 +288,12 @@ Sales-domain agents, skills, and templates are physically relocated into a `pack
 - UI: false
 - Platform: web
 - Manual: false
+- Spec-Required: true
+- Spec: docs/specs/SPEC-005.md
 - PRD-Ref: none (kit self-development; rationale in conversation 2026-05-30)
 - Priority: P1
 - Estimate: 1d
-- Status: backlog
+- Status: done
 - Owner:
 - Branch:
 - GH-Issue:


### PR DESCRIPTION
## Summary
After ISSUE-004 (sales pack split) and ISSUE-009 (\`--pack\` install flag), the README was pre-split. This PR brings it current.

**Counts**
- Tagline: "33 engineering agents + 23 skills" (core) + optional sales pack (5/5)
- "Why" bullet, Agents section header, Project Structure all updated
- templates/ count: 26 (sales 7 moved to packs/sales/templates/)
- Test badge: 530 → 917

**Positioning**
- New "trustworthy code in collaboration → AI dev team control plane" framing
- Adds Decision capture as a top-level bullet (the \`/spec\` layer)
- Reframes Specialized agents to mention the design-auditor / ui-reviewer scope split

**Brainstorm/bizanalysis demotion**
- Workflow diagrams and Decision Tree no longer place these on the default path
- Framed as "optional pre-PRD" primitives (skills unchanged)

**New sections**
- **Packs** (after Skill Orchestration): table + rules + link to packs/README.md
- **Team-scale usage** (after Installation): Pattern (a) monorepo + Pattern (b) virtual monorepo wrapper + explicit "Why no separate team layer" rationale so contributors don't re-propose it
- **Roadmap** (after Agents): ISSUE-001/002/003/008 with one-sentence each, no dates; list of Cluster C+D shipped work this session

**Installation**
- New \`--pack=core|sales|all\` examples
- Post-install diagram reflects new counts
- Note about destructive re-install behavior

## Test plan
- [x] \`validate_issues.py issues.md\` — 13/13 pass
- [x] \`validate_spec.py docs/specs/\` — 9/9 SPECs pass
- [x] \`gen_skills.py --dry-run\` — 25 SKILL.md fresh
- [x] Grep for stale counts (32/22/21) — none remain
- [x] Counts match \`ls agents/ skills/ packs/sales/agents/ packs/sales/skills/\`
- [ ] Manual: render README in GitHub UI; verify all section anchors work, no broken internal links

Self-documenting: \`docs/specs/SPEC-005.md\`.

Closes ISSUE-005

🤖 Generated with [Claude Code](https://claude.com/claude-code)