### PR TITLE
fix(ci): make pyyaml a hard dep; lazy-fail at parse time, never at import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov pyyaml
           if [ -f pyproject.toml ]; then pip install -e ".[dev]" 2>/dev/null || true; fi
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
@@ -38,4 +38,16 @@ jobs:
         run: |
           if [ -f issues.md ]; then
             python scripts/validate_issues.py issues.md
+          fi
+
+      - name: Validate pack manifests (if any)
+        run: |
+          if [ -d packs ]; then
+            python scripts/validate_pack_manifest.py packs/
+          fi
+
+      - name: Validate SPECs (if any)
+        run: |
+          if [ -d docs/specs ]; then
+            python scripts/validate_spec.py docs/specs/
           fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dev = [
     "pytest-mock>=3.0",
     "pytest-asyncio>=0.23",
     "pytest-xdist>=3.0",
+    "pyyaml>=6.0",
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/validate_pack_manifest.py
+++ b/scripts/validate_pack_manifest.py
@@ -39,12 +39,21 @@ from typing import Any
 
 try:
     import yaml  # type: ignore
-except ImportError:
-    print(
-        "error: PyYAML is required. Install with: uv add --dev pyyaml",
-        file=sys.stderr,
-    )
-    sys.exit(2)
+except ImportError:  # pragma: no cover — only hit when PyYAML is absent
+    yaml = None  # type: ignore[assignment]
+
+
+def _require_yaml() -> None:
+    """Fail loudly with an install hint at the point YAML parsing is actually needed.
+
+    Importing this module must not trigger sys.exit — that breaks unrelated
+    test collection on environments where PyYAML isn't installed yet.
+    """
+    if yaml is None:
+        raise ImportError(
+            "PyYAML is required for pack manifest parsing. "
+            "Install with: uv add --dev pyyaml  OR  pip install pyyaml"
+        )
 
 
 REQUIRED_FIELDS = {"name", "description", "depends_on"}
@@ -52,6 +61,7 @@ OPTIONAL_LIST_FIELDS = {"agents", "skills", "templates"}
 
 
 def _load_manifest(path: Path) -> dict[str, Any]:
+    _require_yaml()
     text = path.read_text(encoding="utf-8")
     data = yaml.safe_load(text)
     if not isinstance(data, dict):
@@ -76,7 +86,11 @@ def _validate_single(
 
     try:
         manifest = _load_manifest(manifest_path)
-    except (yaml.YAMLError, ValueError) as exc:
+    except ImportError as exc:
+        # PyYAML is not installed — surface as a clean validation failure.
+        return [f"{manifest_path}: {exc}"]
+    except Exception as exc:
+        # YAMLError, ValueError, and any other parser-level failure.
         return [f"{manifest_path}: failed to parse YAML — {exc}"]
 
     # Required fields

--- a/tests/test_validate_pack_manifest.py
+++ b/tests/test_validate_pack_manifest.py
@@ -253,3 +253,49 @@ class TestRealSalesManifest:
             pytest.skip("packs/sales/manifest.yaml not present in this checkout")
         rc = main([str(manifest)])
         assert rc == 0
+
+
+class TestPyYamlImportContract:
+    """Regression: importing validate_pack_manifest must NOT sys.exit when
+    PyYAML is missing. The CI failure on PR #29-#32 was caused by a
+    module-level sys.exit(2) breaking unrelated test collection. Yaml errors
+    must surface only when YAML parsing is actually invoked.
+    """
+
+    def test_module_import_is_safe(self):
+        # Importing should never raise SystemExit, even if PyYAML is missing.
+        # (We're testing the contract; PyYAML IS installed in this test env.)
+        import importlib
+
+        import scripts.validate_pack_manifest as mod
+
+        importlib.reload(mod)
+        # Successful reload is the contract.
+        assert hasattr(mod, "_load_manifest")
+        assert hasattr(mod, "validate_packs")
+
+    def test_lazy_failure_surface(self, monkeypatch, tmp_path: Path):
+        """When yaml is None at parse time, _load_manifest raises ImportError
+        with an install hint — not SystemExit."""
+        import scripts.validate_pack_manifest as mod
+
+        manifest = tmp_path / "manifest.yaml"
+        manifest.write_text("name: x\n", encoding="utf-8")
+        monkeypatch.setattr(mod, "yaml", None)
+        with pytest.raises(ImportError, match="PyYAML is required"):
+            mod._load_manifest(manifest)
+
+    def test_validate_packs_surfaces_yaml_missing_cleanly(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """validate_packs() should turn a missing-yaml ImportError into a clean
+        validation error, not a crash."""
+        from scripts.validate_pack_manifest import validate_packs
+
+        manifest = _make_pack(tmp_path)
+        import scripts.validate_pack_manifest as mod
+
+        monkeypatch.setattr(mod, "yaml", None)
+        count, errors = validate_packs(manifest)
+        assert count == 1
+        assert any("PyYAML is required" in e for e in errors)


### PR DESCRIPTION
## Summary
CI has been failing on every PR since ISSUE-004 (PR #29). Root cause: \`scripts/validate_pack_manifest.py\` called \`sys.exit(2)\` at module import when PyYAML was absent. That broke unrelated pytest collection — any test file transitively importing the module hit \`INTERNALERROR\` before tests could run.

## Why CI hid this
The install line \`pip install -e ".[dev]" 2>/dev/null || true\` silently swallows install failures, and pyyaml was not in the explicit bootstrap line. \`[dev]\` extras also didn't list pyyaml. So CI never had yaml available, and the module-level guard panicked.

## Fix
- **\`scripts/validate_pack_manifest.py\`**: module import sets \`yaml=None\` on \`ImportError\` instead of \`sys.exit\`. New \`_require_yaml()\` raises \`ImportError\` with install hint at parse time. \`validate_packs()\` catches that and returns a clean validation error instead of crashing.
- **\`.github/workflows/ci.yml\`**: explicit \`pip install ... pyyaml\` so yaml is always present even if the \`[dev]\` extras install silently fails. Adds two new CI gates that would have caught this earlier:
  - \`scripts/validate_pack_manifest.py packs/\`
  - \`scripts/validate_spec.py docs/specs/\`
- **\`pyproject.toml\`**: \`pyyaml>=6.0\` added to \`optional-dependencies.dev\`.

## Test plan
- [x] 3 new regression tests in \`test_validate_pack_manifest.py\` (module import safe, \`_load_manifest\` raises \`ImportError\` when yaml is None, \`validate_packs\` surfaces missing-yaml cleanly)
- [x] Full pack-related suite — 36 passed
- [x] Manual sanity: blocked yaml import; module loads OK
- [ ] Verify CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)