### PR TITLE
fix(checkpoint): repair install wiring, runner detection, and parallel-merge conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ __pycache__/
 # uv.lock must be tracked for reproducible builds
 !uv.lock
 
+# Per-worktree freeze marker (absolute path); never tracked — committing it
+# caused parallel branches to merge-conflict on disjoint source.
+.claude-kit/freeze-dir.txt
+
 # Environment & secrets
 .env
 .env.*

--- a/project/.claude/hooks/autotest.py
+++ b/project/.claude/hooks/autotest.py
@@ -67,14 +67,68 @@ def find_js_test(filepath: str) -> str | None:
     return None
 
 
-def find_js_runner() -> list[str] | None:
-    """Detect available JS test runner."""
+def _find_up(start_dir: str, *relpaths: str) -> str | None:
+    """Walk up from start_dir, returning the first existing relpath match."""
+    d = os.path.abspath(start_dir)
+    while True:
+        for rel in relpaths:
+            cand = os.path.join(d, rel)
+            if os.path.exists(cand):
+                return cand
+        parent = os.path.dirname(d)
+        if parent == d:
+            return None
+        d = parent
+
+
+def _pkg_has_dep(start_dir: str, dep: str) -> bool:
+    """True if the nearest package.json declares `dep` in (dev)dependencies."""
+    pkg = _find_up(start_dir, "package.json")
+    if not pkg:
+        return False
+    try:
+        with open(pkg, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return False
+    return any(
+        dep in (data.get(key) or {})
+        for key in ("dependencies", "devDependencies")
+    )
+
+
+def find_js_runner(test_file: str) -> list[str] | None:
+    """Detect the JS test runner, preferring locally-installed binaries.
+
+    `shutil.which` only sees the global PATH, but vitest/jest are almost always
+    installed locally under `node_modules/.bin`. Missing the local binary used
+    to fall back to `npx jest`, which can't run TS/ESM test files and produced
+    a false "Test failed" on every edit even when vitest was green. So:
+      1. Prefer a local `node_modules/.bin/{vitest,jest}` near the test file.
+      2. If the project declares vitest but has no local binary yet, use
+         `npx vitest` — never fall back to jest for a vitest project.
+      3. Only then consider a global vitest/jest, and `npx jest` last.
+    """
+    start = os.path.dirname(os.path.abspath(test_file))
+    has_vitest = _pkg_has_dep(start, "vitest")
+
+    local_vitest = _find_up(start, os.path.join("node_modules", ".bin", "vitest"))
+    if local_vitest:
+        return [local_vitest, "run"]
+    local_jest = _find_up(start, os.path.join("node_modules", ".bin", "jest"))
+    if local_jest:
+        return [local_jest, "--no-coverage"]
+
+    npx = shutil.which("npx")
+    if has_vitest and npx:
+        return [npx, "vitest", "run"]
     if shutil.which("vitest"):
         return ["vitest", "run"]
     if shutil.which("jest"):
         return ["jest", "--no-coverage"]
-    npx = shutil.which("npx")
-    if npx:
+    # Don't run jest against a vitest project's TS/ESM tests — guaranteed false
+    # failure. Only use the npx jest fallback when vitest isn't in play.
+    if npx and not has_vitest:
         return [npx, "jest", "--no-coverage"]
     return None
 
@@ -108,7 +162,7 @@ def run_python_test(test_file: str) -> dict | None:
 
 
 def run_js_test(test_file: str) -> dict | None:
-    runner = find_js_runner()
+    runner = find_js_runner(test_file)
     if not runner:
         return None
 

--- a/scripts/checkpoint.sh
+++ b/scripts/checkpoint.sh
@@ -13,5 +13,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT="$(bash "$SCRIPT_DIR/worktree.sh" root)"
-exec python3 "$ROOT/scripts/verify_checkpoint.py" "$@"
+# verify_checkpoint.py always lives beside this script, so resolve it via
+# SCRIPT_DIR rather than "$ROOT/scripts/…". This keeps the checkpoint working
+# even when the kit's scripts/ isn't symlinked at the repo root.
+exec python3 "$SCRIPT_DIR/verify_checkpoint.py" "$@"

--- a/scripts/install_project.sh
+++ b/scripts/install_project.sh
@@ -55,8 +55,40 @@ if ! command -v prettier &>/dev/null; then
   npm install -g prettier 2>/dev/null || true
 fi
 
+# ── Expose kit scripts at the project root ────────────────────────────
+# Skill templates invoke `bash scripts/<name>` (checkpoint.sh, wt_setup.sh,
+# verify_checkpoint.py, …) from the repo root, and the permission allowlist is
+# prefix-matched on `scripts/`. So the kit's scripts/ must be reachable there.
+# Prefer a single directory symlink (keeps inter-script imports / sibling
+# lookups working). If the project already has its own real scripts/ dir,
+# symlink each kit script in individually, skipping name collisions.
+if [ -e "$PROJ_ROOT/scripts" ] && [ ! -L "$PROJ_ROOT/scripts" ]; then
+  echo "  Project has its own scripts/ — linking kit scripts individually."
+  for src in "$KIT_ROOT"/scripts/*; do
+    name="$(basename "$src")"
+    [ "$name" = "__pycache__" ] && continue
+    dst="$PROJ_ROOT/scripts/$name"
+    if [ -e "$dst" ] && [ ! -L "$dst" ]; then
+      echo "  ⚠️  skip scripts/$name (project already has its own)"
+      continue
+    fi
+    ln -sfn "$src" "$dst"
+  done
+else
+  ln -sfn "$KIT_ROOT/scripts" "$PROJ_ROOT/scripts"
+fi
+
 # ── Linter config symlinks ────────────────────────────────────────────
 ln -sfn "$KIT_ROOT/linters/ruff.toml" "$PROJ_ROOT/ruff.toml"
 ln -sfn "$KIT_ROOT/linters/.prettierrc.json" "$PROJ_ROOT/.prettierrc.json"
+
+# ── Ignore the per-worktree freeze marker ─────────────────────────────
+# wt_setup.sh writes an absolute path into .claude-kit/freeze-dir.txt inside
+# each worktree. If committed, parallel branches merge-conflict on it even
+# when their source diffs are disjoint. Make sure it's ignored.
+GITIGNORE="$PROJ_ROOT/.gitignore"
+if ! { [ -f "$GITIGNORE" ] && grep -qxF '.claude-kit/freeze-dir.txt' "$GITIGNORE"; }; then
+  printf '\n# claude-dev-kit: per-worktree freeze marker (never track)\n.claude-kit/freeze-dir.txt\n' >> "$GITIGNORE"
+fi
 
 echo "✅ Installed kit into: $PROJ_ROOT/.claude"

--- a/scripts/verify_checkpoint.py
+++ b/scripts/verify_checkpoint.py
@@ -596,15 +596,15 @@ def verify_implement_red(issue_id: str, **_) -> bool:
         print(f"FAIL: test files have no real assertions: {', '.join(shallow)}")
         return False
 
-    # Now run tests — they SHOULD FAIL (exit code != 0)
-    has_python = (
-        (wt / "pyproject.toml").exists()
-        or (wt / "setup.py").exists()
-        or (wt / "tests").is_dir()
-    )
+    # Now run tests — they SHOULD FAIL (exit code != 0).
+    # Use explicit runner detection so a JS/TS repo with a `tests/` dir isn't
+    # mis-run through pytest (which collects 0 tests → exit 5 → a *fake* RED
+    # pass even when the real JS suite would have passed).
+    has_python, has_js = _detect_test_runners(wt)
 
-    if has_python:
-        result = _run(["python3", "-m", "pytest", "-q", "--tb=short"], cwd=wt_path, timeout=60)
+    # JS first: an explicit scripts.test is the strongest signal.
+    if has_js:
+        result = _run(["npm", "test", "--", "--passWithNoTests"], cwd=wt_path, timeout=60)
         if result.returncode == 0:
             print("FAIL: RED phase — tests passed but should fail before implementation.")
             print("  TDD requires: write failing tests first, then implement to make them pass.")
@@ -612,12 +612,11 @@ def verify_implement_red(issue_id: str, **_) -> bool:
         print(f"PASS: RED phase — tests fail as expected (exit {result.returncode})")
         return True
 
-    # JS/TS fallback
-    has_js = (wt / "package.json").exists()
-    if has_js:
-        result = _run(["npm", "test", "--", "--passWithNoTests"], cwd=wt_path, timeout=60)
+    if has_python:
+        result = _run(["python3", "-m", "pytest", "-q", "--tb=short"], cwd=wt_path, timeout=60)
         if result.returncode == 0:
             print("FAIL: RED phase — tests passed but should fail before implementation.")
+            print("  TDD requires: write failing tests first, then implement to make them pass.")
             return False
         print(f"PASS: RED phase — tests fail as expected (exit {result.returncode})")
         return True
@@ -775,6 +774,39 @@ def _run_js_tests_in_worktree(cwd: str | None) -> bool:
     return True
 
 
+def _detect_test_runners(wt: Path) -> tuple[bool, bool]:
+    """Decide which test runners apply, from explicit project signals.
+
+    Returns (has_python, has_js).
+
+    JS is signalled by ``package.json`` declaring a ``scripts.test`` entry —
+    the strongest, least-ambiguous signal a JS/TS project provides.
+
+    Python is signalled by ``pyproject.toml`` or ``setup.py``. A bare
+    ``tests/`` directory or stray ``*.py`` is deliberately NOT treated as a
+    Python signal: JS/TS repos routinely have a ``tests/`` directory (for
+    fixtures or non-Python tooling), which previously forced pytest to run
+    and fail with "no tests ran, 0% coverage" even though the JS suite was
+    green. Loose ``*.py`` detection only kicks in when no JS test runner was
+    found, as a last resort for script-style Python projects without packaging
+    metadata.
+    """
+    has_js = False
+    pkg = wt / "package.json"
+    if pkg.exists():
+        try:
+            data = json.loads(pkg.read_text(encoding="utf-8"))
+            has_js = "test" in (data.get("scripts") or {})
+        except (OSError, json.JSONDecodeError):
+            has_js = False
+
+    has_python = (wt / "pyproject.toml").exists() or (wt / "setup.py").exists()
+    if not has_python and not has_js:
+        has_python = any(wt.glob("*.py"))
+
+    return has_python, has_js
+
+
 def _test_plan_has_high_risk(root: Path) -> bool:
     """Check if test_plan.md Risk Matrix contains High or Critical risk flows."""
     test_plan = root / "docs" / "test_plan.md"
@@ -841,12 +873,19 @@ def _ensure_deps_installed(wt: Path, cwd: str | None) -> bool:
     """
     ok = True
 
-    # JS/TS: install node_modules if package.json exists but node_modules doesn't
+    # JS/TS: install node_modules if package.json exists but node_modules doesn't.
+    # Honor the repo's package manager (lockfile) instead of forcing npm.
     if (wt / "package.json").exists() and not (wt / "node_modules").is_dir():
-        print("  Installing npm dependencies in worktree...")
-        result = _run(["npm", "install", "--legacy-peer-deps"], cwd=cwd, timeout=120)
+        if (wt / "pnpm-lock.yaml").exists():
+            install_cmd = ["pnpm", "install"]
+        elif (wt / "yarn.lock").exists():
+            install_cmd = ["yarn", "install"]
+        else:
+            install_cmd = ["npm", "install", "--legacy-peer-deps"]
+        print(f"  Installing JS dependencies in worktree ({install_cmd[0]})...")
+        result = _run(install_cmd, cwd=cwd, timeout=120)
         if result.returncode != 0:
-            print(f"  WARN: npm install failed (exit {result.returncode})")
+            print(f"  WARN: {install_cmd[0]} install failed (exit {result.returncode})")
             ok = False
 
     # Python: install if pyproject.toml exists
@@ -870,13 +909,7 @@ def verify_implement_test(issue_id: str, **_) -> bool:
     # Ensure dependencies are installed before running tests
     _ensure_deps_installed(wt, cwd)
 
-    has_python = (
-        (wt / "pyproject.toml").exists()
-        or (wt / "setup.py").exists()
-        or any(wt.glob("*.py"))
-        or (wt / "tests").is_dir()
-    )
-    has_js = (wt / "package.json").exists()
+    has_python, has_js = _detect_test_runners(wt)
 
     ok = True
 
@@ -956,7 +989,13 @@ def verify_implement_pr(issue_id: str, **_) -> bool:
 
 
 def verify_implement_registry(issue_id: str, **_) -> bool:
-    """Status=done and PR field exists in issues.md."""
+    """Status is a valid implement-end state and a PR field exists in issues.md.
+
+    /implement opens a PR but does NOT merge it, so ``doing`` (PR in flight) is
+    the normal terminal state for this phase. ``done`` is also accepted for
+    flows that mark completion here. The ``done``-only requirement is enforced
+    at the ship/merge phase, not implement.
+    """
     block = _find_issue_block(issue_id)
     if block is None:
         return False
@@ -964,18 +1003,39 @@ def verify_implement_registry(issue_id: str, **_) -> bool:
     status = _extract_field(block, "Status")
     pr_field = _extract_field(block, "PR")
 
-    if status != "done":
-        print(f"FAIL: {issue_id} Status is '{status}', expected 'done'")
+    if status not in ("doing", "done"):
+        print(f"FAIL: {issue_id} Status is '{status}', expected 'doing' or 'done'")
         return False
     if not pr_field:
         print(f"FAIL: {issue_id} has no PR field")
         return False
 
-    print(f"PASS: {issue_id} registry updated (Status=done, PR present)")
+    print(f"PASS: {issue_id} registry updated (Status={status}, PR present)")
     return True
 
 
 # ── Review skill verifiers ───────────────────────────────────────────
+
+
+def _review_notes_path(wt: Path, basename: str, issue_id: str) -> Path | None:
+    """Resolve a review-notes file, preferring the per-issue path.
+
+    Parallel pipelines all appended to a single shared ``docs/<basename>.md``,
+    which produced repeated merge conflicts even when the source diffs were
+    disjoint. The per-issue path ``docs/<basename>/<ISSUE-ID>.md`` keeps each
+    branch's notes in its own file. The legacy single-file location is still
+    accepted as a fallback so existing repos and in-flight branches keep
+    working.
+
+    Returns the resolved Path, or None if neither location exists.
+    """
+    per_issue = wt / "docs" / basename / f"{issue_id}.md"
+    if per_issue.exists():
+        return per_issue
+    legacy = wt / "docs" / f"{basename}.md"
+    if legacy.exists():
+        return legacy
+    return None
 
 
 def verify_review_checkout(issue_id: str, **_) -> bool:
@@ -990,9 +1050,12 @@ def verify_review_review(issue_id: str, **_) -> bool:
         print(f"FAIL: no worktree found for {issue_id}")
         return False
 
-    notes = Path(wt_path) / "docs" / "review_notes.md"
-    if not notes.exists():
-        print("FAIL: docs/review_notes.md not found in worktree")
+    notes = _review_notes_path(Path(wt_path), "review_notes", issue_id)
+    if notes is None:
+        print(
+            f"FAIL: docs/review_notes/{issue_id}.md "
+            "(or legacy docs/review_notes.md) not found in worktree"
+        )
         return False
 
     content = notes.read_text(encoding="utf-8")
@@ -1059,9 +1122,12 @@ def verify_review_ui_review(issue_id: str, **_) -> bool:
         print(f"FAIL: no worktree found for {issue_id}")
         return False
 
-    notes = Path(wt_path) / "docs" / "ui_review_notes.md"
-    if not notes.exists():
-        print("FAIL: docs/ui_review_notes.md not found in worktree")
+    notes = _review_notes_path(Path(wt_path), "ui_review_notes", issue_id)
+    if notes is None:
+        print(
+            f"FAIL: docs/ui_review_notes/{issue_id}.md "
+            "(or legacy docs/ui_review_notes.md) not found in worktree"
+        )
         return False
 
     content = notes.read_text(encoding="utf-8")
@@ -1363,25 +1429,37 @@ def verify_ship_checks(issue_id: str, **_) -> bool:
     if pr_num is None:
         return False
 
-    # Wait for CI checks to appear (up to 60 seconds)
+    # Wait up to 60s for all checks to go green (CI may not have started yet
+    # right after PR creation). Break early once `gh pr checks` exits 0.
     max_wait = 60
     waited = 0
-    lines: list[str] = []
     result = _run_with_retry(["gh", "pr", "checks", pr_num])
     while waited < max_wait:
         result = _run_with_retry(["gh", "pr", "checks", pr_num])
         if result.returncode == 0:
-            lines = [line for line in result.stdout.strip().splitlines() if line.strip()]
-            if lines:
-                break
+            break
         if waited == 0:
             print(f"  Waiting for CI checks on PR #{pr_num}...", flush=True)
         time.sleep(5)
         waited += 5
 
+    # Parse the check rows regardless of exit code: `gh pr checks` still writes
+    # one row per check to stdout when checks are failing/pending. An empty
+    # stdout means there are NO checks registered at all.
+    lines = [line for line in (result.stdout or "").splitlines() if line.strip()]
+
     if not lines:
-        print(f"FAIL: PR #{pr_num} has no CI checks after {max_wait}s")
-        return False
+        # No checks registered on the PR. Legitimate for deploy-only repos
+        # (workflows all `on: workflow_dispatch`, so no PR-triggered CI). Treat
+        # as a non-blocking SKIP rather than a false failure — but warn loudly
+        # so a repo that *should* have CI but silently lost it doesn't pass
+        # unnoticed. (Failing checks DO produce rows, so they still FAIL below.)
+        print(
+            f"SKIP: PR #{pr_num} has no CI checks registered after {max_wait}s "
+            "(deploy-only repo or no PR-triggered CI). Treating as PASS — "
+            "verify CI coverage manually if this repo is expected to run checks."
+        )
+        return True
 
     if result.returncode != 0:
         print(f"FAIL: gh pr checks failed for PR #{pr_num}")

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -150,7 +150,7 @@ Steps:
    Run: `python3 scripts/verify_visual_diff.py --project-path $WT --threshold 5`
    This is a **non-blocking advisory signal**, NOT a gate. Pixel comparison across different renderers (Figma vs Chromium) inherently produces false positives due to font hinting, anti-aliasing, and sub-pixel rendering differences.
    - Generates diff images in `figma-export/visual-diff/` (red = real diff, yellow = AA)
-   - Log the diff percentage in `docs/review_notes.md` for the reviewer to assess
+   - Log the diff percentage in `docs/review_notes/$ARGUMENTS.md` for the reviewer to assess
    - If diff > 5%: flag as a **warning** in review notes — reviewer should inspect the diff images
    - Do NOT block the review based on pixel diff alone. The **figma-compliance checkpoint** (step 3.5) is the authoritative Figma fidelity gate.
 
@@ -158,7 +158,7 @@ Steps:
    Ask ui-reviewer subagent to perform UI state review:
    - Pass the UI context files gathered in step 3 plus `docs/review_lessons.md`.
    - Reviewer checks state coverage, copy compliance, token usage, accessibility, interaction fidelity.
-   - Output: `docs/ui_review_notes.md` with severity-classified findings.
+   - Output: `docs/ui_review_notes/$ARGUMENTS.md` with severity-classified findings.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
 > Run: `bash scripts/checkpoint.sh --skill review --phase ui-review --issue $ARGUMENTS`
@@ -190,7 +190,7 @@ Steps:
 > Run: `bash scripts/checkpoint.sh --skill review --phase test-quality --issue $ARGUMENTS`
 > If exit code ≠ 0: STOP immediately and report the failure. Do NOT proceed.
 
-5) Update docs/review_notes.md (inside `$WT/`) with sections:
+5) Update docs/review_notes/$ARGUMENTS.md (inside `$WT/`) with sections:
    - **Code Review**: findings, changes, follow-ups.
    - **Security Findings**: severity-classified list with remediation steps.
    - **UI Review** (from ui-reviewer, if applicable): State Coverage, Copy, Tokens, Accessibility.
@@ -224,15 +224,15 @@ These are registry files managed only on main. Always use `bash scripts/registry
 
 ## Error Handling
 - If PR not found (issues.md has no PR field and `gh pr status` returns nothing): stop and report; suggest running `/implement` first.
-- If reviewer subagent fails: retry once; if still failing, skip automated review and log a warning in docs/review_notes.md.
+- If reviewer subagent fails: retry once; if still failing, skip automated review and log a warning in docs/review_notes/$ARGUMENTS.md.
 - If applied fixes break tests:
   1. Revert the fix commits: `git checkout -- <files>` for unstaged or `git revert HEAD` for committed changes (inside `$WT/`).
   2. Re-run tests to confirm the branch is back to a passing state.
-  3. Log the failed fix attempt in docs/review_notes.md as a follow-up item.
+  3. Log the failed fix attempt in docs/review_notes/$ARGUMENTS.md as a follow-up item.
 - If `gh pr ready` fails: report the error but do not block — the PR can be manually marked ready.
 
 ## Rollback
 - Review changes are commits on the existing PR branch.
 - If review fixes must be fully undone: `git revert` the review commits (do not force-push).
-- docs/review_notes.md is append-only; no rollback needed for notes.
+- docs/review_notes/$ARGUMENTS.md is append-only; no rollback needed for notes.
 - Clean up worktree when done: `bash scripts/wt_cleanup.sh "$BRANCH"`.

--- a/skills/review/SKILL.md.tmpl
+++ b/skills/review/SKILL.md.tmpl
@@ -77,7 +77,7 @@ Steps:
    Run: `python3 scripts/verify_visual_diff.py --project-path $WT --threshold 5`
    This is a **non-blocking advisory signal**, NOT a gate. Pixel comparison across different renderers (Figma vs Chromium) inherently produces false positives due to font hinting, anti-aliasing, and sub-pixel rendering differences.
    - Generates diff images in `figma-export/visual-diff/` (red = real diff, yellow = AA)
-   - Log the diff percentage in `docs/review_notes.md` for the reviewer to assess
+   - Log the diff percentage in `docs/review_notes/$ARGUMENTS.md` for the reviewer to assess
    - If diff > 5%: flag as a **warning** in review notes — reviewer should inspect the diff images
    - Do NOT block the review based on pixel diff alone. The **figma-compliance checkpoint** (step 3.5) is the authoritative Figma fidelity gate.
 
@@ -85,7 +85,7 @@ Steps:
    Ask ui-reviewer subagent to perform UI state review:
    - Pass the UI context files gathered in step 3 plus `docs/review_lessons.md`.
    - Reviewer checks state coverage, copy compliance, token usage, accessibility, interaction fidelity.
-   - Output: `docs/ui_review_notes.md` with severity-classified findings.
+   - Output: `docs/ui_review_notes/$ARGUMENTS.md` with severity-classified findings.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
 > Run: `bash scripts/checkpoint.sh --skill review --phase ui-review --issue $ARGUMENTS`
@@ -117,7 +117,7 @@ Steps:
 > Run: `bash scripts/checkpoint.sh --skill review --phase test-quality --issue $ARGUMENTS`
 > If exit code ≠ 0: STOP immediately and report the failure. Do NOT proceed.
 
-5) Update docs/review_notes.md (inside `$WT/`) with sections:
+5) Update docs/review_notes/$ARGUMENTS.md (inside `$WT/`) with sections:
    - **Code Review**: findings, changes, follow-ups.
    - **Security Findings**: severity-classified list with remediation steps.
    - **UI Review** (from ui-reviewer, if applicable): State Coverage, Copy, Tokens, Accessibility.
@@ -151,15 +151,15 @@ These are registry files managed only on main. Always use `bash scripts/registry
 
 ## Error Handling
 - If PR not found (issues.md has no PR field and `gh pr status` returns nothing): stop and report; suggest running `/implement` first.
-- If reviewer subagent fails: retry once; if still failing, skip automated review and log a warning in docs/review_notes.md.
+- If reviewer subagent fails: retry once; if still failing, skip automated review and log a warning in docs/review_notes/$ARGUMENTS.md.
 - If applied fixes break tests:
   1. Revert the fix commits: `git checkout -- <files>` for unstaged or `git revert HEAD` for committed changes (inside `$WT/`).
   2. Re-run tests to confirm the branch is back to a passing state.
-  3. Log the failed fix attempt in docs/review_notes.md as a follow-up item.
+  3. Log the failed fix attempt in docs/review_notes/$ARGUMENTS.md as a follow-up item.
 - If `gh pr ready` fails: report the error but do not block — the PR can be manually marked ready.
 
 ## Rollback
 - Review changes are commits on the existing PR branch.
 - If review fixes must be fully undone: `git revert` the review commits (do not force-push).
-- docs/review_notes.md is append-only; no rollback needed for notes.
+- docs/review_notes/$ARGUMENTS.md is append-only; no rollback needed for notes.
 - Clean up worktree when done: `bash scripts/wt_cleanup.sh "$BRANCH"`.

--- a/tests/test_autotest.py
+++ b/tests/test_autotest.py
@@ -392,3 +392,50 @@ class TestNonTargetTools:
         }
         out = run_hook(payload)
         assert out is None
+
+
+class TestFindJsRunner:
+    def _load(self):
+        sys.path.insert(0, str(SCRIPT.parent))
+        import importlib
+        import autotest
+        importlib.reload(autotest)
+        return autotest
+
+    def test_prefers_local_vitest_bin(self):
+        autotest = self._load()
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            bin_dir = root / "node_modules" / ".bin"
+            bin_dir.mkdir(parents=True)
+            (bin_dir / "vitest").write_text("#!/bin/sh\n")
+            (root / "package.json").write_text('{"devDependencies": {"vitest": "^1"}}')
+            test_file = root / "src" / "a.test.ts"
+            test_file.parent.mkdir()
+            test_file.write_text("test('x', () => {})\n")
+
+            runner = autotest.find_js_runner(str(test_file))
+            assert runner is not None
+            assert runner[0].endswith(os.path.join("node_modules", ".bin", "vitest"))
+            assert runner[1] == "run"
+
+    def test_no_jest_fallback_for_vitest_project(self):
+        # vitest declared but no local bin and no global vitest/jest:
+        # must NOT fall back to `npx jest` (would mis-run TS/ESM tests).
+        autotest = self._load()
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "package.json").write_text('{"devDependencies": {"vitest": "^1"}}')
+            test_file = root / "a.test.ts"
+            test_file.write_text("test('x', () => {})\n")
+
+            import shutil as _sh
+            from unittest.mock import patch
+
+            def fake_which(name):
+                return "/usr/bin/npx" if name == "npx" else None
+
+            with patch.object(_sh, "which", side_effect=fake_which):
+                runner = autotest.find_js_runner(str(test_file))
+            # Should choose npx vitest, never npx jest.
+            assert runner == ["/usr/bin/npx", "vitest", "run"]

--- a/tests/test_verify_checkpoint.py
+++ b/tests/test_verify_checkpoint.py
@@ -601,14 +601,59 @@ class TestVerifyImplementRegistry:
         )
         assert vc.verify_implement_registry("ISSUE-001") is True
 
-    def test_fail_when_status_not_done(self, repo_root):
+    def test_pass_when_doing_with_pr(self, repo_root):
+        # /implement opens a PR but does not merge, so `doing` is the normal
+        # terminal state for the implement phase.
         _setup_issues(
             repo_root,
             "### ISSUE-001: Test\n"
             "- Status: doing\n"
             "- PR: https://github.com/org/repo/pull/42\n",
         )
+        assert vc.verify_implement_registry("ISSUE-001") is True
+
+    def test_fail_when_status_invalid(self, repo_root):
+        _setup_issues(
+            repo_root,
+            "### ISSUE-001: Test\n"
+            "- Status: backlog\n"
+            "- PR: https://github.com/org/repo/pull/42\n",
+        )
         assert vc.verify_implement_registry("ISSUE-001") is False
+
+    def test_fail_when_no_pr(self, repo_root):
+        _setup_issues(
+            repo_root,
+            "### ISSUE-001: Test\n- Status: doing\n",
+        )
+        assert vc.verify_implement_registry("ISSUE-001") is False
+
+
+class TestDetectTestRunners:
+    def test_js_repo_with_fixtures_dir_is_not_python(self, tmp_path):
+        # A JS/TS repo with a tests/ fixtures dir must NOT be forced through
+        # pytest just because tests/ exists (the original false-positive).
+        (tmp_path / "package.json").write_text('{"scripts": {"test": "vitest run"}}')
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "tests" / "fixtures.json").write_text("{}")
+
+        has_python, has_js = vc._detect_test_runners(tmp_path)
+        assert (has_python, has_js) == (False, True)
+
+    def test_python_repo_via_pyproject(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+        has_python, has_js = vc._detect_test_runners(tmp_path)
+        assert (has_python, has_js) == (True, False)
+
+    def test_package_json_without_test_script_is_not_js(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"scripts": {"build": "tsc"}}')
+        has_python, has_js = vc._detect_test_runners(tmp_path)
+        assert has_js is False
+
+    def test_loose_python_fallback_only_without_js(self, tmp_path):
+        (tmp_path / "script.py").write_text("print('hi')\n")
+        has_python, has_js = vc._detect_test_runners(tmp_path)
+        assert (has_python, has_js) == (True, False)
 
 
 # ── Review verifiers ─────────────────────────────────────────────────
@@ -632,6 +677,19 @@ class TestVerifyReviewReview:
         notes_dir.mkdir(parents=True)
         (notes_dir / "review_notes.md").write_text(
             "## Code Review\nFindings.\n\n## Security Findings\nNone.\n"
+        )
+
+        with patch.object(vc, "_run", return_value=_mock_run(0, stdout=wt_stdout)):
+            assert vc.verify_review_review("ISSUE-001") is True
+
+    def test_pass_with_per_issue_path(self, tmp_path):
+        # Per-issue file (docs/review_notes/<ISSUE>.md) avoids parallel-merge
+        # conflicts on a single shared docs/review_notes.md.
+        wt_stdout = f"worktree {tmp_path}/wt/issue/issue-001-slug\n"
+        notes_dir = tmp_path / "wt" / "issue" / "issue-001-slug" / "docs" / "review_notes"
+        notes_dir.mkdir(parents=True)
+        (notes_dir / "ISSUE-001.md").write_text(
+            "# Code Review\nFindings.\n\n# Security Findings\nNone.\n"
         )
 
         with patch.object(vc, "_run", return_value=_mock_run(0, stdout=wt_stdout)):
@@ -933,17 +991,24 @@ class TestVerifyShipChecks:
         with patch.object(vc, "_run", return_value=_mock_run(0, stdout="build\tpass\t1m\ntest\tpass\t2m\n")):
             assert vc.verify_ship_checks("ISSUE-001") is True
 
-    def test_fail_when_no_checks_configured(self, repo_root):
-        """Empty stdout from gh pr checks means no CI — should fail."""
+    def test_skip_when_no_checks_configured(self, repo_root):
+        """Empty stdout from gh pr checks means no CI is registered.
+
+        This is legitimate for deploy-only repos (workflows all on
+        workflow_dispatch), so it is a non-blocking SKIP/PASS — not a failure.
+        """
         _setup_issues(repo_root, "### ISSUE-001: Test\n- PR: #42\n")
 
         with patch.object(vc, "_run", return_value=_mock_run(0, stdout="")):
-            assert vc.verify_ship_checks("ISSUE-001") is False
+            assert vc.verify_ship_checks("ISSUE-001") is True
 
     def test_fail_when_checks_fail(self, repo_root):
+        # Failing checks DO emit rows to stdout (with a non-zero exit), so they
+        # must still FAIL — distinct from the "no checks at all" SKIP case.
         _setup_issues(repo_root, "### ISSUE-001: Test\n- PR: #42\n")
 
-        with patch.object(vc, "_run", return_value=_mock_run(1, stdout="build\tfail\n")):
+        with patch.object(vc, "_run", return_value=_mock_run(1, stdout="build\tfail\n")), \
+                patch.object(vc.time, "sleep", lambda *_a, **_k: None):
             assert vc.verify_ship_checks("ISSUE-001") is False
 
 


### PR DESCRIPTION
검토 리포트의 7개 결함을 전부 수정합니다 (`/implement`는 PR까지 — registry는 `doing` 정상으로 확정).

## 수정 내역

| # | Sev | 수정 |
|---|---|---|
| **#1** | High | `install_project.sh`가 `scripts/`를 repo-root에 노출 안 해 모든 스킬 명령이 깨지던 문제. 디렉터리 심볼릭(소비자 자체 `scripts/`가 있으면 충돌 회피 per-entry). `checkpoint.sh`는 `verify_checkpoint.py`를 `$SCRIPT_DIR`에서 해석 |
| **#2** | High | `tests/` 디렉터리/잔여 `*.py`만으로 Python 오판 → JS/TS 레포에서 pytest 강제 실패 & RED 가짜 통과(exit 5). `_detect_test_runners()` 도입(JS=`scripts.test`, Python=`pyproject.toml`/`setup.py`). deps 설치는 lockfile로 pnpm/yarn/npm 구분 |
| **#3** | Med | registry가 `Status==done` 강제 → implement-only 흐름 충돌. `doing`(또는 done)+PR 허용, `done`은 ship에서 |
| **#4** | Med | ship checks가 CI 존재 전제 → deploy-only 레포 false-negative. "체크 없음"은 SKIP+경고, "체크 실패"는 그대로 FAIL(구분) |
| **#5** | Med | `.claude-kit/freeze-dir.txt` 추적 → 병렬 머지 충돌. gitignore + 소비자 `.gitignore` 주입 |
| **#6** | Low | 공유 `docs/review_notes.md` append 충돌 → 이슈별 `docs/review_notes/<ISSUE>.md`(레거시 fallback) |
| **#7** | Low | autotest가 로컬 `node_modules/.bin/vitest` 못 찾아 `npx jest` 폴백(TS/ESM 오탐). 로컬 bin 우선, vitest 프로젝트는 jest 폴백 금지 |

## 검증
- `test_verify_checkpoint.py`: **118 passed**
- `test_autotest.py`: **23 passed**
- `test_gen_skills.py` / `test_install_packs.py` 통과, shell 문법·py 컴파일 OK
- 신규 테스트: `_detect_test_runners`, `find_js_runner` 로컬 bin, per-issue review notes, registry doing/invalid/no-PR, ship-checks SKIP vs FAIL

## 참고
- #1 심볼릭: 소비자 자체 `scripts/`의 동명 스크립트는 skip + 경고
- #4: CI 필수 정책이 필요하면 별도 config 게이트 추가 가능
- #6: `design_audit.md`/`a11y_audit.md`는 checkpoint 미검증이라 이번 범위 제외

🤖 Generated with [Claude Code](https://claude.com/claude-code)