### PR TITLE
feat(implement,review): ponytail-benchmarked minimality axis (ISSUE-018~020) + benchmarks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,24 @@ Thanks for your interest in contributing!
 2. Run `python3 scripts/gen_skills.py` to generate `SKILL.md`
 3. Never edit `SKILL.md` directly -- always edit the `.tmpl` file
 
+## Marking Tech Debt (KIT-DEBT)
+
+When you intentionally defer a simplification or take a shortcut, mark it inline so it
+becomes a *tracked* obligation instead of silent rot. Every marker must carry a
+**ceiling** (the constraint that makes the shortcut acceptable today) and an
+**upgrade trigger** (the condition that forces a revisit):
+
+```python
+# KIT-DEBT(ceiling=<=100 items, trigger=list grows unbounded or p95 > 50ms): linear scan; fine at current scale
+```
+```js
+// KIT-DEBT(ceiling=single region, trigger=multi-region rollout): hardcoded endpoint
+```
+
+- A marker **without** `trigger=` is flagged `no-trigger` ("later means never") — avoid it.
+- Harvest the ledger any time with `python3 scripts/debt_harvest.py` (use `--json` for tooling).
+- `/review` runs this as a non-blocking advisory phase and surfaces no-trigger markers in the review notes.
+
 ## Running Tests
 
 ```bash

--- a/agents/developer.md
+++ b/agents/developer.md
@@ -33,7 +33,7 @@ Role: You are a senior developer. You write working code with tests, following t
    - Test files must exist in the diff (e.g., `test_*.py` in `tests/`). The checkpoint will verify this.
    - If you skip this step, the `tests-written` checkpoint will fail and block the entire pipeline.
 8. **Verify RED**: Run the tests. They MUST fail because no implementation exists yet. This confirms your tests are validating real behavior, not vacuously passing. The `red` checkpoint enforces this.
-9. **Implement**: Write minimal code to make all tests pass. Follow the project's existing style. One concern per function/method.
+9. **Implement**: Walk the Decision Ladder below, then write the minimum code that makes all tests pass. Follow the project's existing style. One concern per function/method.
 10. **Run tests (GREEN)**: `pytest` must pass. Fix implementation (not tests) until green.
 11. **Self-Review (Mandatory before commit)**:
     - **AC coverage check**: Re-read every AC in the issue. Does the implementation satisfy each one? List any gaps.
@@ -48,6 +48,24 @@ Role: You are a senior developer. You write working code with tests, following t
 12. **Commit + push**: Clear commit messages following Conventional Commits.
 13. **Create PR**: PR body starts with `Closes #<issue_number>`. Include a summary of changes.
 14. **Update registry**: Set Branch/GH-Issue/PR/Status in `issues.md`.
+
+## Decision Ladder (walk before writing code)
+
+Before generating any implementation, walk these rungs in order and stop at the first that satisfies the need. This runs *after* tests are written and RED-verified — it shapes the implementation, never the test coverage.
+
+1. **Does this need to exist? (YAGNI)** — If the AC doesn't require it, don't build it.
+2. **Does the standard library already do this?** — Use it instead of reinventing.
+3. **Does a native platform/framework feature cover it?** — Prefer the built-in.
+4. **Does an already-installed dependency solve it?** — Reuse before adding.
+5. **Can it be one line / one small function?** — Make it so.
+6. **Only then:** write the minimum code that works and matches existing patterns.
+
+**Over-engineering prohibitions:**
+- No abstraction (interface, factory, layer, config knob) that wasn't explicitly requested or that has a single implementation/caller.
+- No new dependency if it can reasonably be avoided.
+- No boilerplate nobody asked for. Deletion over addition. Boring over clever. Fewest files possible.
+
+**The non-negotiable exception — laziness never touches safety.** "Lazy code without its check is unfinished." The ladder NEVER licenses skipping: the tests required by TDD, input validation at trust boundaries, error handling that prevents data loss, security controls, accessibility, Figma/design fidelity, or anything explicitly requested in the issue. Minimal means *less code*, not *less correct*.
 
 ## Coding Standards
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -23,8 +23,24 @@ Role: You are a senior code reviewer with security expertise. You perform both a
 - **XSS**: cross-site scripting in any user-facing output
 - **Misconfiguration**: debug mode in production, permissive CORS, etc.
 
+### Over-Engineering (minimality axis)
+Review the diff for **unnecessary complexity only — not correctness** (correctness is the Code Quality pass above). The kit's TDD + multi-auditor pipeline biases toward *adding* code; this axis is the counterweight. Classify each finding with one tag:
+
+- **delete** — dead code or a speculative feature nobody asked for
+- **stdlib** — reinvents something the standard library already provides
+- **native** — a dependency doing what the language/platform/framework does natively
+- **yagni** — an abstraction (interface, factory, layer, config knob) with exactly one implementation/caller
+- **shrink** — same logic, materially fewer lines
+
+Rules:
+- One line per finding: `path:line: <tag> <what to cut> → <replacement>`.
+- End the section with the **net removable lines** (rough estimate).
+- If the diff is already lean, emit exactly: `Lean already. Ship.` — do NOT pad with weak findings.
+- **Laziness never overrides safety.** Never recommend cutting input validation at trust boundaries, error handling that prevents data loss, security controls, accessibility, or anything explicitly requested in the issue. "Lazy code without its check is unfinished."
+- This axis **reports**; it does not rewrite. Apply a cut yourself only when it is a trivial, obviously-safe deletion — otherwise leave it as a finding (see the NEVER-rewrite rule below).
+
 ## Output
-- `docs/review_notes.md` with two sections: **Code Review** and **Security Findings**
+- `docs/review_notes.md` with three sections: **Code Review**, **Security Findings**, and **Over-Engineering**
 - `docs/review_lessons.md` — update with newly identified preventable patterns (see Learning Extraction below)
 - Security findings classified by severity (Critical / High / Medium / Low)
 - Apply minimal safe fixes and re-run tests
@@ -64,7 +80,7 @@ After completing your review and before writing `docs/review_notes.md`, perform 
 After completing the review, extract preventable patterns into `docs/review_lessons.md`:
 
 1. Identify findings that could have been prevented earlier (at kickoff or implementation time).
-2. Classify each into: **Code Quality**, **Security**, **Testing**, or **Architecture**.
+2. Classify each into: **Code Quality**, **Security**, **Testing**, **Architecture**, or **Over-Engineering**.
 3. If the pattern already exists in `docs/review_lessons.md`: increment its Frequency and append the current issue to Observed-In.
 4. If the pattern is new: create a new entry with the next `[RL-NNN]` ID.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,83 @@
+# Ponytail-axis benchmarks
+
+Measures the effect of the ponytail-benchmarked changes (ISSUE-018/019/020) on
+the kit's agents. Two experiments, both A/B with the **model held constant**
+(`sonnet`) across arms so the measured delta isolates the prompt change, not the
+model.
+
+> **Read the caveats.** N is small, fixtures are hand-authored, runs are
+> single-shot (no variance estimate), and the over-engineering ground truth is
+> author-labelled. These are **directional** signals, not statistics. They were
+> run on 2026-06-22.
+
+## Experiment 1 — Over-engineering review axis (ISSUE-018)
+
+`ponytail_axis/` — 6 fixtures (4 with planted over-engineering, 2 lean controls).
+Each reviewed by two reviewer prompts: **baseline** (Code-Quality + Security
+checklist) vs **treatment** (+ the over-engineering axis with `delete/stdlib/
+native/yagni/shrink` tags). Findings scored against `expected.json`
+(`score.py`): a finding hits a planted item if its line is within ±3 lines.
+
+Reproduce: `python3 ponytail_axis/score.py`
+
+| arm | recall | hits | tag-match | lean false-pos |
+|-----|--------|------|-----------|----------------|
+| baseline  | 100% | 8/8 | 0%  | 0/2 |
+| treatment | 100% | 8/8 | 88% | 0/2 |
+
+**Finding — recall saturated; the value is classification and direction, not detection.**
+The planted over-engineering was blatant enough that the baseline's existing
+"complexity and duplication" check caught the same lines (100% both arms). The
+axis changed two things the recall number hides:
+
+1. **Classification: 0% → 88% correct tags.** Baseline flags the line but does
+   not label it as a *cut*; treatment labels it `delete`/`stdlib`/`yagni`, which
+   is what makes a finding actionable and gradeable.
+2. **Direction flip (the real signal).** On fixture `03` the **baseline
+   recommended *adding* a `Notifier` ABC/Protocol**, and on `01` "add a second
+   source to justify the ABC" — i.e. baseline pushed *toward more abstraction*
+   on the exact lines the treatment said to delete. Without the minimality axis,
+   a reviewer's default instinct is to add structure, not remove it.
+
+Neither arm produced false positives on the lean controls — the axis did not
+manufacture findings on already-clean code (it emitted "Lean already. Ship.").
+
+**Limitation:** the fixtures were too easy to separate the arms on recall. A
+harder fixture set (subtle over-engineering a quality review would miss) is
+needed to measure a detection delta. Logged here rather than hidden.
+
+## Experiment 2 — Decision-ladder LOC (ISSUE-019)
+
+`ladder/` — 3 over-engineering-tempting tasks. Each implemented by two developer
+prompts: **baseline** (senior-dev framing) vs **treatment** (+ the six-rung
+decision ladder). Logical code lines counted by `measure_loc.py` (tokenize-based;
+excludes blanks, comments, and docstrings so verbose docs don't skew it).
+
+Reproduce: `python3 ladder/measure_loc.py`
+
+| task | baseline SLOC | treatment SLOC | reduction |
+|------|---------------|----------------|-----------|
+| A — read JSON config value | 53 | 10 | 81% |
+| B — N most-recent items     | 12 | 10 | 17% |
+| C — feature-flag check      | 37 | 5  | 86% |
+| **TOTAL** | **102** | **25** | **75%** |
+
+**Finding — 75% fewer logical LOC, concentrated where baseline over-built.**
+Baseline C built a 37-line immutable `FeatureFlags` class (`__contains__`, `get`,
+`_validate_key`, `__repr__`, defensive copy) for "is this flag enabled?";
+treatment wrote a 5-line function. Baseline A added a `_MISSING` sentinel,
+`KeyError` path, and a `__main__` smoke-test block; treatment used
+`dict.get(key, default)`. Where baseline was already near-minimal (task B), the
+ladder forced almost no change (17%) — it does not cut for cutting's sake. This
+matches ponytail's own pattern: large reductions on over-engineered tasks,
+little on lean ones.
+
+**Safety preserved.** Every treatment implementation kept input validation
+(`isinstance` guards, JSON-object checks) — consistent with the rule that the
+ladder never overrides validation/error-handling/security.
+
+## Experiment 3 — Debt harvester (ISSUE-020)
+
+Not a performance benchmark — the harvester's value is *correctness*, covered by
+`tests/test_debt_harvest.py` (9/9: valid markers parsed, `no-trigger` flagged,
+clean tree message, malformed handled, vendor dirs and binaries skipped).

--- a/benchmarks/ladder/measure_loc.py
+++ b/benchmarks/ladder/measure_loc.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Measure logical lines of code (SLOC) per implementation, per arm.
+
+SLOC = physical lines containing at least one token that is not a comment,
+string/docstring, or layout token. This fairly excludes docstrings and
+comments so verbose documentation does not inflate one arm over another.
+
+Usage:
+    python3 measure_loc.py        # scan ./results/{baseline,treatment}/task*.py
+"""
+
+from __future__ import annotations
+
+import token
+import tokenize
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+# Names may not all exist across Python versions (FSTRING_* added in 3.12).
+_SKIP_NAMES = ["COMMENT", "STRING", "NL", "NEWLINE", "INDENT", "DEDENT",
+               "ENCODING", "ENDMARKER", "FSTRING_START", "FSTRING_MIDDLE",
+               "FSTRING_END"]
+SKIP = {getattr(token, n) for n in _SKIP_NAMES if hasattr(token, n)}
+
+
+def sloc(path: Path) -> int:
+    code_lines: set[int] = set()
+    with path.open("rb") as f:
+        for tok in tokenize.tokenize(f.readline):
+            if tok.type not in SKIP and tok.string.strip():
+                code_lines.add(tok.start[0])
+    return len(code_lines)
+
+
+def nonblank(path: Path) -> int:
+    return sum(1 for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip())
+
+
+def main() -> int:
+    arms = ["baseline", "treatment"]
+    tasks = sorted({p.name for arm in arms for p in (HERE / "results" / arm).glob("task*.py")})
+
+    print(f"{'task':<8} {'baseline_sloc':>14} {'treatment_sloc':>15} {'delta':>8} {'reduction':>10}")
+    print("-" * 60)
+    tot_b = tot_t = 0
+    for t in tasks:
+        b = sloc(HERE / "results" / "baseline" / t)
+        tr = sloc(HERE / "results" / "treatment" / t)
+        tot_b += b
+        tot_t += tr
+        red = f"{(b - tr) / b:.0%}" if b else "—"
+        print(f"{t:<8} {b:>14} {tr:>15} {b - tr:>8} {red:>10}")
+    print("-" * 60)
+    red = f"{(tot_b - tot_t) / tot_b:.0%}" if tot_b else "—"
+    print(f"{'TOTAL':<8} {tot_b:>14} {tot_t:>15} {tot_b - tot_t:>8} {red:>10}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/ladder/results/baseline/taskA.py
+++ b/benchmarks/ladder/results/baseline/taskA.py
@@ -1,0 +1,102 @@
+"""
+config_reader.py — Read a single value from a JSON config file by key.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+_MISSING = object()
+
+
+def get_config_value(
+    config_path: str | Path,
+    key: str,
+    default: Any = _MISSING,
+) -> Any:
+    """Return the value for *key* from the JSON config file at *config_path*.
+
+    Parameters
+    ----------
+    config_path:
+        Path to the JSON file on disk.
+    key:
+        Top-level key to look up in the parsed JSON object.
+    default:
+        Value to return when the key is absent from the config.
+        If omitted and the key is missing, ``KeyError`` is raised.
+
+    Raises
+    ------
+    FileNotFoundError
+        If *config_path* does not exist.
+    ValueError
+        If the file content is not a valid JSON object (dict).
+    KeyError
+        If *key* is absent and no *default* was supplied.
+    """
+    path = Path(config_path)
+
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    with path.open("r", encoding="utf-8") as fh:
+        try:
+            data = json.load(fh)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in config file '{path}': {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Config file '{path}' must contain a JSON object (dict), "
+            f"got {type(data).__name__}."
+        )
+
+    if key in data:
+        return data[key]
+
+    if default is not _MISSING:
+        return default
+
+    raise KeyError(f"Key '{key}' not found in config file '{path}'.")
+
+
+# ---------------------------------------------------------------------------
+# Example / smoke-test (runs only when executed directly)
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import tempfile
+    import os
+
+    sample = {"host": "localhost", "port": 5432, "debug": True}
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False, encoding="utf-8"
+    ) as tmp:
+        json.dump(sample, tmp)
+        tmp_path = tmp.name
+
+    try:
+        assert get_config_value(tmp_path, "host") == "localhost"
+        assert get_config_value(tmp_path, "port") == 5432
+        assert get_config_value(tmp_path, "missing_key", default="fallback") == "fallback"
+        assert get_config_value(tmp_path, "missing_key", default=None) is None
+
+        try:
+            get_config_value(tmp_path, "missing_key")
+            assert False, "Expected KeyError"
+        except KeyError:
+            pass
+
+        try:
+            get_config_value("/nonexistent/path/config.json", "key")
+            assert False, "Expected FileNotFoundError"
+        except FileNotFoundError:
+            pass
+
+        print("All assertions passed.")
+    finally:
+        os.unlink(tmp_path)

--- a/benchmarks/ladder/results/baseline/taskB.py
+++ b/benchmarks/ladder/results/baseline/taskB.py
@@ -1,0 +1,38 @@
+"""
+most_recent.py
+--------------
+Utility for extracting values from the N most recent items in a list of
+timestamp/value dicts.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class TimestampedItem(TypedDict):
+    timestamp: int
+    value: str
+
+
+def most_recent_values(items: list[TimestampedItem], n: int) -> list[str]:
+    """Return the values of the N most recent items, ordered highest timestamp first.
+
+    Args:
+        items: A list of dicts, each with an integer 'timestamp' and a string 'value'.
+        n:     The maximum number of results to return.
+
+    Returns:
+        A list of at most *n* value strings, sorted by descending timestamp.
+
+    Raises:
+        ValueError: If *n* is negative.
+        TypeError:  If any item is missing the required keys or has wrong types.
+    """
+    if n < 0:
+        raise ValueError(f"n must be non-negative, got {n!r}")
+    if n == 0:
+        return []
+
+    sorted_items = sorted(items, key=lambda item: item["timestamp"], reverse=True)
+    return [item["value"] for item in sorted_items[:n]]

--- a/benchmarks/ladder/results/baseline/taskC.py
+++ b/benchmarks/ladder/results/baseline/taskC.py
@@ -1,0 +1,136 @@
+"""Feature flag management module.
+
+Provides a simple, immutable interface for checking whether named feature flags
+are enabled, treating unknown flags as disabled.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Optional
+
+
+class FeatureFlags:
+    """Immutable feature flag registry.
+
+    Parameters
+    ----------
+    flags:
+        A mapping of flag names to their enabled state.  The mapping is
+        copied on construction so later mutations to the source dict do not
+        affect this instance.
+
+    Examples
+    --------
+    >>> flags = FeatureFlags({"dark_mode": True, "beta_ui": False})
+    >>> flags.is_enabled("dark_mode")
+    True
+    >>> flags.is_enabled("beta_ui")
+    False
+    >>> flags.is_enabled("unknown_flag")
+    False
+    """
+
+    def __init__(self, flags: Mapping[str, bool]) -> None:
+        if not isinstance(flags, Mapping):
+            raise TypeError(f"flags must be a Mapping, got {type(flags).__name__!r}")
+        self._flags: dict[str, bool] = {
+            self._validate_key(k): bool(v) for k, v in flags.items()
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def is_enabled(self, name: str) -> bool:
+        """Return ``True`` if *name* is a known, enabled flag; ``False`` otherwise.
+
+        An unknown flag is treated as disabled.
+
+        Parameters
+        ----------
+        name:
+            The feature flag name to check.
+
+        Returns
+        -------
+        bool
+            Enabled state of the flag (``False`` for unknown flags).
+        """
+        if not isinstance(name, str):
+            raise TypeError(f"flag name must be a str, got {type(name).__name__!r}")
+        return self._flags.get(name, False)
+
+    def get(self, name: str, default: Optional[bool] = None) -> Optional[bool]:
+        """Return the flag value, or *default* if the flag is not registered.
+
+        Unlike :meth:`is_enabled`, this preserves the distinction between an
+        explicitly disabled flag and an unknown flag when *default* differs
+        from ``False``.
+
+        Parameters
+        ----------
+        name:
+            The feature flag name.
+        default:
+            Value returned when *name* is not present in the registry.
+            Defaults to ``None``.
+        """
+        if not isinstance(name, str):
+            raise TypeError(f"flag name must be a str, got {type(name).__name__!r}")
+        return self._flags.get(name, default)
+
+    def __contains__(self, name: object) -> bool:
+        """Return ``True`` if *name* is a registered flag (enabled or not)."""
+        return name in self._flags
+
+    def __len__(self) -> int:
+        return len(self._flags)
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"{self.__class__.__name__}({self._flags!r})"
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_key(key: object) -> str:
+        if not isinstance(key, str):
+            raise TypeError(f"flag names must be str, got {type(key).__name__!r}")
+        if not key:
+            raise ValueError("flag name must not be empty")
+        return key
+
+
+def is_enabled(flags: Mapping[str, bool], name: str) -> bool:
+    """Check whether a feature flag is enabled in a plain mapping.
+
+    Functional convenience wrapper that avoids constructing a
+    :class:`FeatureFlags` instance for one-off checks.
+
+    Parameters
+    ----------
+    flags:
+        A mapping of flag names to their enabled state.
+    name:
+        The feature flag name to check.
+
+    Returns
+    -------
+    bool
+        ``True`` if the flag exists and is ``True``; ``False`` otherwise.
+        An unknown flag is treated as disabled.
+
+    Examples
+    --------
+    >>> is_enabled({"dark_mode": True}, "dark_mode")
+    True
+    >>> is_enabled({"dark_mode": True}, "missing")
+    False
+    """
+    if not isinstance(flags, Mapping):
+        raise TypeError(f"flags must be a Mapping, got {type(flags).__name__!r}")
+    if not isinstance(name, str):
+        raise TypeError(f"flag name must be a str, got {type(name).__name__!r}")
+    return bool(flags.get(name, False))

--- a/benchmarks/ladder/results/treatment/taskA.py
+++ b/benchmarks/ladder/results/treatment/taskA.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+from typing import Any
+
+
+def get_config_value(config_path: str | Path, key: str, default: Any = None) -> Any:
+    path = Path(config_path)
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"{config_path!r} must contain a JSON object at the top level")
+    return data.get(key, default)

--- a/benchmarks/ladder/results/treatment/taskB.py
+++ b/benchmarks/ladder/results/treatment/taskB.py
@@ -1,0 +1,12 @@
+from typing import Any
+
+
+def recent_values(items: list[dict], n: int) -> list[str]:
+    if not isinstance(items, list):
+        raise TypeError("items must be a list")
+    if not isinstance(n, int) or n < 0:
+        raise ValueError("n must be a non-negative integer")
+    return [
+        item["value"]
+        for item in sorted(items, key=lambda x: x["timestamp"], reverse=True)[:n]
+    ]

--- a/benchmarks/ladder/results/treatment/taskC.py
+++ b/benchmarks/ladder/results/treatment/taskC.py
@@ -1,0 +1,8 @@
+from typing import Mapping
+
+
+def is_enabled(flags: Mapping[str, bool], name: str) -> bool:
+    """Return True if *name* is present and enabled in *flags*, False otherwise."""
+    if not isinstance(name, str):
+        raise TypeError(f"flag name must be a str, got {type(name).__name__!r}")
+    return bool(flags.get(name, False))

--- a/benchmarks/ponytail_axis/expected.json
+++ b/benchmarks/ponytail_axis/expected.json
@@ -1,0 +1,41 @@
+{
+  "_doc": "Ground truth for the over-engineering detection benchmark. Each planted item is a deliberately-introduced over-engineering instance. A finding 'hits' a planted item if its reported line falls within [line_lo-3, line_hi+3]. Tag match is recorded but not required for a hit (reviewers may phrase the same cut differently). Lean fixtures must yield NO substantive cut findings — any cut on them is a false positive.",
+  "fixtures": {
+    "01_settings_loader.py": {
+      "lean": false,
+      "planted": [
+        {"id": "abc-one-impl", "tag": "yagni", "line_lo": 6, "line_hi": 9, "what": "SettingsSource ABC with a single implementation"},
+        {"id": "manual-json", "tag": "stdlib", "line_lo": 17, "line_hi": 22, "what": "hand-rolled JSON parsing; use json.load"}
+      ]
+    },
+    "02_order_totals.py": {
+      "lean": false,
+      "planted": [
+        {"id": "dead-legacy-round", "tag": "delete", "line_lo": 4, "line_hi": 7, "what": "_legacy_round is never called"},
+        {"id": "manual-sum", "tag": "stdlib", "line_lo": 11, "line_hi": 13, "what": "manual accumulation loop; use sum()"},
+        {"id": "manual-map", "tag": "shrink", "line_lo": 18, "line_hi": 21, "what": "append loop; use a comprehension"}
+      ]
+    },
+    "03_notifier_factory.py": {
+      "lean": false,
+      "planted": [
+        {"id": "factory-one-product", "tag": "yagni", "line_lo": 4, "line_hi": 8, "what": "NotifierFactory abstracts a single product"}
+      ]
+    },
+    "04_unique_sorted.py": {
+      "lean": false,
+      "planted": [
+        {"id": "manual-dedup", "tag": "stdlib", "line_lo": 5, "line_hi": 12, "what": "nested-loop dedup; use set()"},
+        {"id": "bubble-sort", "tag": "stdlib", "line_lo": 13, "line_hi": 18, "what": "hand-written bubble sort; use sorted()"}
+      ]
+    },
+    "05_lean_slugify.py": {
+      "lean": true,
+      "planted": []
+    },
+    "06_lean_withdraw.py": {
+      "lean": true,
+      "planted": []
+    }
+  }
+}

--- a/benchmarks/ponytail_axis/fixtures/01_settings_loader.py
+++ b/benchmarks/ponytail_axis/fixtures/01_settings_loader.py
@@ -1,0 +1,27 @@
+"""Load user settings from a JSON file."""
+
+import abc
+
+
+class SettingsSource(abc.ABC):
+    @abc.abstractmethod
+    def load(self) -> dict:
+        ...
+
+
+class JsonFileSource(SettingsSource):
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    def load(self) -> dict:
+        text = open(self.path).read()
+        result = {}
+        for pair in text.strip("{} \n").split(","):
+            key, value = pair.split(":")
+            result[key.strip().strip('"')] = value.strip().strip('"')
+        return result
+
+
+def get_settings(path: str) -> dict:
+    source = JsonFileSource(path)
+    return source.load()

--- a/benchmarks/ponytail_axis/fixtures/02_order_totals.py
+++ b/benchmarks/ponytail_axis/fixtures/02_order_totals.py
@@ -1,0 +1,21 @@
+"""Compute order totals."""
+
+
+def _legacy_round(value: float) -> float:
+    # Old rounding helper kept "just in case". Nothing calls it anymore.
+    factor = 100.0
+    return int(value * factor + 0.5) / factor
+
+
+def total_with_tax(prices: list[float], tax_rate: float) -> float:
+    subtotal = 0.0
+    for price in prices:
+        subtotal = subtotal + price
+    return round(subtotal * (1 + tax_rate), 2)
+
+
+def line_item_names(items: list[dict]) -> list[str]:
+    names = []
+    for item in items:
+        names.append(item["name"])
+    return names

--- a/benchmarks/ponytail_axis/fixtures/03_notifier_factory.py
+++ b/benchmarks/ponytail_axis/fixtures/03_notifier_factory.py
@@ -1,0 +1,19 @@
+"""Send a notification to a user."""
+
+
+class NotifierFactory:
+    def create(self, kind: str):
+        if kind == "email":
+            return EmailNotifier()
+        raise ValueError(f"unknown notifier: {kind}")
+
+
+class EmailNotifier:
+    def send(self, to: str, body: str) -> None:
+        print(f"emailing {to}: {body}")
+
+
+def notify_user(email: str, message: str) -> None:
+    factory = NotifierFactory()
+    notifier = factory.create("email")
+    notifier.send(email, message)

--- a/benchmarks/ponytail_axis/fixtures/04_unique_sorted.py
+++ b/benchmarks/ponytail_axis/fixtures/04_unique_sorted.py
@@ -1,0 +1,19 @@
+"""Return the unique tags from a list, sorted."""
+
+
+def unique_sorted_tags(tags: list[str]) -> list[str]:
+    seen = []
+    for tag in tags:
+        already = False
+        for existing in seen:
+            if existing == tag:
+                already = True
+        if not already:
+            seen.append(tag)
+    # bubble sort the result
+    n = len(seen)
+    for i in range(n):
+        for j in range(0, n - i - 1):
+            if seen[j] > seen[j + 1]:
+                seen[j], seen[j + 1] = seen[j + 1], seen[j]
+    return seen

--- a/benchmarks/ponytail_axis/fixtures/05_lean_slugify.py
+++ b/benchmarks/ponytail_axis/fixtures/05_lean_slugify.py
@@ -1,0 +1,8 @@
+"""Convert a title into a URL slug."""
+
+import re
+
+
+def slugify(title: str) -> str:
+    lowered = title.strip().lower()
+    return re.sub(r"[^a-z0-9]+", "-", lowered).strip("-")

--- a/benchmarks/ponytail_axis/fixtures/06_lean_withdraw.py
+++ b/benchmarks/ponytail_axis/fixtures/06_lean_withdraw.py
@@ -1,0 +1,9 @@
+"""Withdraw an amount from an account balance."""
+
+
+def withdraw(balance: float, amount: float) -> float:
+    if amount <= 0:
+        raise ValueError("amount must be positive")
+    if amount > balance:
+        raise ValueError("insufficient funds")
+    return balance - amount

--- a/benchmarks/ponytail_axis/results/baseline/01_settings_loader.py.json
+++ b/benchmarks/ponytail_axis/results/baseline/01_settings_loader.py.json
@@ -1,0 +1,50 @@
+{
+  "lean_verdict": false,
+  "findings": [
+    {
+      "line": 17,
+      "tag": "resource-leak",
+      "what": "file never closed"
+    },
+    {
+      "line": 17,
+      "tag": "no-error-handling",
+      "what": "no try/except on IO"
+    },
+    {
+      "line": 19,
+      "tag": "fragile-parser",
+      "what": "hand-rolled JSON parse breaks on nested/commas"
+    },
+    {
+      "line": 20,
+      "tag": "unpack-error",
+      "what": "split(':') too many values"
+    },
+    {
+      "line": 19,
+      "tag": "empty-input",
+      "what": "empty file raises"
+    },
+    {
+      "line": 21,
+      "tag": "type-loss",
+      "what": "all values become strings"
+    },
+    {
+      "line": 25,
+      "tag": "unnecessary-indirection",
+      "what": "get_settings adds no value"
+    },
+    {
+      "line": 6,
+      "tag": "unused-abstraction",
+      "what": "ABC with one subclass"
+    },
+    {
+      "line": 1,
+      "tag": "missing-tests",
+      "what": "no tests"
+    }
+  ]
+}

--- a/benchmarks/ponytail_axis/results/baseline/02_order_totals.py.json
+++ b/benchmarks/ponytail_axis/results/baseline/02_order_totals.py.json
@@ -1,0 +1,45 @@
+{
+  "lean_verdict": false,
+  "findings": [
+    {
+      "line": 4,
+      "tag": "dead-code",
+      "what": "_legacy_round never called"
+    },
+    {
+      "line": 10,
+      "tag": "missing-validation",
+      "what": "negative tax_rate"
+    },
+    {
+      "line": 10,
+      "tag": "missing-validation",
+      "what": "negative prices"
+    },
+    {
+      "line": 10,
+      "tag": "missing-validation",
+      "what": "empty list"
+    },
+    {
+      "line": 11,
+      "tag": "simplification",
+      "what": "use sum(prices)"
+    },
+    {
+      "line": 17,
+      "tag": "simplification",
+      "what": "use comprehension"
+    },
+    {
+      "line": 20,
+      "tag": "missing-validation",
+      "what": "KeyError on name"
+    },
+    {
+      "line": 17,
+      "tag": "weak-typing",
+      "what": "tighten list[dict]"
+    }
+  ]
+}

--- a/benchmarks/ponytail_axis/results/baseline/03_notifier_factory.py.json
+++ b/benchmarks/ponytail_axis/results/baseline/03_notifier_factory.py.json
@@ -1,0 +1,50 @@
+{
+  "lean_verdict": false,
+  "findings": [
+    {
+      "line": 5,
+      "tag": "missing-return-type",
+      "what": "annotate create"
+    },
+    {
+      "line": 4,
+      "tag": "no-abstraction",
+      "what": "factory one kind no base"
+    },
+    {
+      "line": 8,
+      "tag": "no-supported-kinds-list",
+      "what": "list valid kinds"
+    },
+    {
+      "line": 11,
+      "tag": "no-abstraction",
+      "what": "no Notifier protocol"
+    },
+    {
+      "line": 13,
+      "tag": "side-effect-in-library",
+      "what": "print not logger"
+    },
+    {
+      "line": 17,
+      "tag": "unnecessary-instantiation",
+      "what": "new factory each call"
+    },
+    {
+      "line": 18,
+      "tag": "hardcoded-kind",
+      "what": "hardcodes email"
+    },
+    {
+      "line": 1,
+      "tag": "missing-tests",
+      "what": "no tests"
+    },
+    {
+      "line": 4,
+      "tag": "class-order",
+      "what": "forward ref"
+    }
+  ]
+}

--- a/benchmarks/ponytail_axis/results/baseline/04_unique_sorted.py.json
+++ b/benchmarks/ponytail_axis/results/baseline/04_unique_sorted.py.json
@@ -1,0 +1,35 @@
+{
+  "lean_verdict": false,
+  "findings": [
+    {
+      "line": 5,
+      "tag": "reinventing-set",
+      "what": "use dict.fromkeys/set"
+    },
+    {
+      "line": 7,
+      "tag": "unnecessary-flag-variable",
+      "what": "use not in"
+    },
+    {
+      "line": 13,
+      "tag": "reinventing-sort",
+      "what": "use sorted()"
+    },
+    {
+      "line": 4,
+      "tag": "no-none-guard",
+      "what": "None raises"
+    },
+    {
+      "line": 4,
+      "tag": "no-tests",
+      "what": "no tests"
+    },
+    {
+      "line": 1,
+      "tag": "docstring-incomplete",
+      "what": "docstring vague"
+    }
+  ]
+}

--- a/benchmarks/ponytail_axis/results/baseline/05_lean_slugify.py.json
+++ b/benchmarks/ponytail_axis/results/baseline/05_lean_slugify.py.json
@@ -1,0 +1,4 @@
+{
+  "lean_verdict": true,
+  "findings": []
+}

--- a/benchmarks/ponytail_axis/results/baseline/06_lean_withdraw.py.json
+++ b/benchmarks/ponytail_axis/results/baseline/06_lean_withdraw.py.json
@@ -1,0 +1,4 @@
+{
+  "lean_verdict": true,
+  "findings": []
+}

--- a/benchmarks/ponytail_axis/results/treatment/01_settings_loader.py.json
+++ b/benchmarks/ponytail_axis/results/treatment/01_settings_loader.py.json
@@ -1,0 +1,35 @@
+{
+  "lean_verdict": false,
+  "findings": [
+    {
+      "line": 6,
+      "tag": "yagni",
+      "what": "ABC single impl"
+    },
+    {
+      "line": 17,
+      "tag": "native",
+      "what": "use with open"
+    },
+    {
+      "line": 18,
+      "tag": "stdlib",
+      "what": "use json.load"
+    },
+    {
+      "line": 25,
+      "tag": "yagni",
+      "what": "get_settings indirection"
+    },
+    {
+      "line": 19,
+      "tag": "correctness",
+      "what": "comma/colon in values"
+    },
+    {
+      "line": 21,
+      "tag": "correctness",
+      "what": "type loss"
+    }
+  ]
+}

--- a/benchmarks/ponytail_axis/results/treatment/02_order_totals.py.json
+++ b/benchmarks/ponytail_axis/results/treatment/02_order_totals.py.json
@@ -1,0 +1,30 @@
+{
+  "lean_verdict": false,
+  "findings": [
+    {
+      "line": 4,
+      "tag": "delete",
+      "what": "_legacy_round dead"
+    },
+    {
+      "line": 11,
+      "tag": "stdlib",
+      "what": "use sum()"
+    },
+    {
+      "line": 18,
+      "tag": "stdlib",
+      "what": "use comprehension"
+    },
+    {
+      "line": 10,
+      "tag": "correctness",
+      "what": "no validation"
+    },
+    {
+      "line": 17,
+      "tag": "correctness",
+      "what": "KeyError on name"
+    }
+  ]
+}

--- a/benchmarks/ponytail_axis/results/treatment/03_notifier_factory.py.json
+++ b/benchmarks/ponytail_axis/results/treatment/03_notifier_factory.py.json
@@ -1,0 +1,30 @@
+{
+  "lean_verdict": false,
+  "findings": [
+    {
+      "line": 4,
+      "tag": "yagni",
+      "what": "factory one impl"
+    },
+    {
+      "line": 16,
+      "tag": "yagni",
+      "what": "new factory each call"
+    },
+    {
+      "line": 11,
+      "tag": "yagni",
+      "what": "EmailNotifier wraps print"
+    },
+    {
+      "line": 5,
+      "tag": "delete",
+      "what": "dead dispatch"
+    },
+    {
+      "line": 16,
+      "tag": "shrink",
+      "what": "collapse notify_user"
+    }
+  ]
+}

--- a/benchmarks/ponytail_axis/results/treatment/04_unique_sorted.py.json
+++ b/benchmarks/ponytail_axis/results/treatment/04_unique_sorted.py.json
@@ -1,0 +1,30 @@
+{
+  "lean_verdict": false,
+  "findings": [
+    {
+      "line": 5,
+      "tag": "stdlib",
+      "what": "use dict.fromkeys"
+    },
+    {
+      "line": 7,
+      "tag": "shrink",
+      "what": "use not in"
+    },
+    {
+      "line": 13,
+      "tag": "stdlib",
+      "what": "use sorted()"
+    },
+    {
+      "line": 4,
+      "tag": "shrink",
+      "what": "return sorted(set(tags))"
+    },
+    {
+      "line": 1,
+      "tag": "delete",
+      "what": "no tests"
+    }
+  ]
+}

--- a/benchmarks/ponytail_axis/results/treatment/05_lean_slugify.py.json
+++ b/benchmarks/ponytail_axis/results/treatment/05_lean_slugify.py.json
@@ -1,0 +1,4 @@
+{
+  "lean_verdict": true,
+  "findings": []
+}

--- a/benchmarks/ponytail_axis/results/treatment/06_lean_withdraw.py.json
+++ b/benchmarks/ponytail_axis/results/treatment/06_lean_withdraw.py.json
@@ -1,0 +1,4 @@
+{
+  "lean_verdict": true,
+  "findings": []
+}

--- a/benchmarks/ponytail_axis/score.py
+++ b/benchmarks/ponytail_axis/score.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Score over-engineering detection runs against ground truth.
+
+Reads expected.json and per-arm run outputs under results/<arm>/<fixture>.json,
+each shaped {"lean_verdict": bool, "findings": [{"line": int, "tag": str, "what": str}]}.
+
+A finding HITS a planted item if its line falls within [line_lo-PROX, line_hi+PROX].
+Hit detection is tag-agnostic (reviewers phrase the same cut differently); tag
+agreement is reported separately as a bonus signal.
+
+Metrics per arm:
+  - recall      = planted items hit / total planted (over-engineered fixtures)
+  - tag_match   = hits where the finding's tag equals the planted tag / hits
+  - lean_fp     = lean fixtures that got >=1 cut finding (false positives)
+
+Usage:
+    python3 score.py                 # scan ./results/*
+    python3 score.py --results DIR
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+PROX = 3
+HERE = Path(__file__).resolve().parent
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def score_arm(arm_dir: Path, expected: dict) -> dict:
+    planted_total = hits = tag_match = lean_fp = lean_total = 0
+    per_fixture: list[dict] = []
+
+    for fname, spec in expected["fixtures"].items():
+        run_path = arm_dir / f"{fname}.json"
+        run = _load(run_path) if run_path.exists() else {"lean_verdict": True, "findings": []}
+        findings = run.get("findings", []) or []
+
+        if spec["lean"]:
+            lean_total += 1
+            fp = len(findings) > 0
+            lean_fp += 1 if fp else 0
+            per_fixture.append({"fixture": fname, "lean": True, "false_positive": fp,
+                                "n_findings": len(findings)})
+            continue
+
+        f_hits = 0
+        for item in spec["planted"]:
+            planted_total += 1
+            lo, hi = item["line_lo"] - PROX, item["line_hi"] + PROX
+            matched = [f for f in findings if isinstance(f.get("line"), int) and lo <= f["line"] <= hi]
+            if matched:
+                hits += 1
+                f_hits += 1
+                if any(f.get("tag") == item["tag"] for f in matched):
+                    tag_match += 1
+        per_fixture.append({"fixture": fname, "lean": False,
+                            "planted": len(spec["planted"]), "hits": f_hits})
+
+    return {
+        "arm": arm_dir.name,
+        "planted_total": planted_total,
+        "hits": hits,
+        "recall": round(hits / planted_total, 3) if planted_total else None,
+        "tag_match_rate": round(tag_match / hits, 3) if hits else None,
+        "lean_total": lean_total,
+        "lean_false_positives": lean_fp,
+        "per_fixture": per_fixture,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Score over-engineering detection runs.")
+    ap.add_argument("--results", default=str(HERE / "results"))
+    ap.add_argument("--expected", default=str(HERE / "expected.json"))
+    args = ap.parse_args(argv)
+
+    expected = _load(Path(args.expected))
+    results_dir = Path(args.results)
+    arms = sorted(p for p in results_dir.iterdir() if p.is_dir()) if results_dir.is_dir() else []
+    if not arms:
+        print(f"No arm directories under {results_dir}")
+        return 2
+
+    scored = [score_arm(a, expected) for a in arms]
+
+    print(f"{'arm':<12} {'recall':>8} {'hits':>10} {'tag_match':>10} {'lean_FP':>9}")
+    print("-" * 52)
+    for s in scored:
+        recall = f"{s['recall']:.0%}" if s["recall"] is not None else "—"
+        tagm = f"{s['tag_match_rate']:.0%}" if s["tag_match_rate"] is not None else "—"
+        print(f"{s['arm']:<12} {recall:>8} {str(s['hits'])+'/'+str(s['planted_total']):>10} "
+              f"{tagm:>10} {str(s['lean_false_positives'])+'/'+str(s['lean_total']):>9}")
+
+    print()
+    print(json.dumps(scored, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/issues.md
+++ b/issues.md
@@ -27,6 +27,7 @@
 - [ ] ISSUE-018: Over-engineering/simplicity review axis (ponytail benchmark) _(track: platform, P1, 1d)_
 - [ ] ISSUE-019: Decision-ladder preamble for implement developer subagent (ponytail benchmark) _(track: platform, P2, 0.5d)_
 - [ ] ISSUE-020: Tech-debt marker convention + harvester + review checkpoint (ponytail benchmark) _(track: platform, P2, 1d)_
+- [ ] ISSUE-021: PyYAML-dependent tests should skip cleanly when the dep is absent _(track: platform, P2, 0.5d)_
 
 ### Doing
 
@@ -1248,3 +1249,52 @@ A documented `KIT-DEBT:` marker convention (with mandatory ceiling + upgrade tri
 
 #### Rollback
 Delete `scripts/debt_harvest.py`, remove the `debt` checkpoint phase and the convention doc. No runtime dependency — markers are inert comments if the harvester is gone.
+
+---
+
+### ISSUE-021: PyYAML-dependent tests should skip cleanly when the dep is absent
+
+> Discovered 2026-06-22 while running the full suite during the ISSUE-018~020 work. On a venv without PyYAML, `tests/test_validate_pack_manifest.py` and `tests/test_install_packs.py` produce **23 hard failures**, all tracing to the lazy-fail guard added in #33 (`PyYAML is required for pack manifest parsing`). With PyYAML installed, all 36 tests pass. CI is unaffected (it `pip install`s pyyaml explicitly), but a contributor running bare `pytest` sees a misleading wall of red and cannot tell it apart from a real regression. This is the exact confusion that cost time this session.
+
+- Track: platform
+- UI: false
+- Platform: web
+- Manual: false
+- Spec-Required: false
+- Spec:
+- PRD-Ref: none (kit self-development; discovered during ISSUE-018~020, conversation 2026-06-22)
+- Priority: P2
+- Estimate: 0.5d
+- Status: backlog
+- Owner:
+- Branch:
+- GH-Issue:
+- PR:
+- Depends-On: none
+
+#### Goal
+Running `pytest` without PyYAML yields clean **skips** (with a clear reason) for the pyyaml-dependent tests instead of 23 failures, so a bare local run is trustworthy and distinguishable from a real regression.
+
+#### Scope (In/Out)
+- In:
+  - Guard the pyyaml-dependent tests with `pytest.importorskip("yaml", reason="PyYAML not installed; install dev extras")` (module-level in `test_validate_pack_manifest.py` and `test_install_packs.py`, or via a shared fixture/conftest marker).
+  - Document the dev-dependency install path (`pip install -e '.[dev]'` / `uv sync`) in CONTRIBUTING's "Running Tests" section so the dep is obvious.
+- Out:
+  - Making PyYAML a hard runtime dependency (deliberately rejected in #33 — it lazy-fails at parse time by design; this issue is about *test* ergonomics, not runtime).
+  - Changing the production lazy-fail message or behavior.
+
+#### Acceptance Criteria (DoD)
+- [ ] Given a venv WITHOUT PyYAML, when `pytest` runs, then the pack-manifest/install tests report as skipped (not failed) with a reason naming PyYAML, and the overall run shows 0 failures attributable to a missing pyyaml.
+- [ ] Given a venv WITH PyYAML, when `pytest` runs, then those tests execute and pass exactly as today (no behavior change).
+- [ ] Given CONTRIBUTING.md, when read, then the dev-extras install command is documented in the test section.
+
+#### Implementation Notes
+- Prefer `importorskip` at module top — least invasive, no per-test edits, and the skip reason is visible in `-v` output.
+- Confirm no other test files import `yaml` indirectly through a helper; if so, guard those too.
+- Verify the coverage gate still holds (skipped tests don't execute their target code, but those modules are already exercised in CI where pyyaml is present).
+
+#### Tests
+- [ ] Meta: a check (or manual verification documented in the PR) that the suite reports skips, not failures, when `yaml` is uninstallable. A monkeypatch-based test that simulates `ModuleNotFoundError` for `yaml` is acceptable but optional.
+
+#### Rollback
+Remove the `importorskip` guards; behavior reverts to today's hard failures when PyYAML is absent. No runtime impact.

--- a/issues.md
+++ b/issues.md
@@ -24,6 +24,9 @@
 - [ ] ISSUE-015: Adopt agent effort tiers + refresh model references _(track: platform, P2, 1d)_
 - [ ] ISSUE-016: Worktree/session lifecycle hooks — auto-freeze + run/ cleanup _(track: platform, P2, 1d)_
 - [ ] ISSUE-017: Migrate kit packaging to Claude Code plugin system _(track: platform, P1, 1.5d — spec)_
+- [ ] ISSUE-018: Over-engineering/simplicity review axis (ponytail benchmark) _(track: platform, P1, 1d)_
+- [ ] ISSUE-019: Decision-ladder preamble for implement developer subagent (ponytail benchmark) _(track: platform, P2, 0.5d)_
+- [ ] ISSUE-020: Tech-debt marker convention + harvester + review checkpoint (ponytail benchmark) _(track: platform, P2, 1d)_
 
 ### Doing
 
@@ -1085,3 +1088,163 @@ A reviewed SPEC (`docs/specs/SPEC-017.md`) defines how the kit is packaged as a 
 
 #### Rollback
 Abandon SPEC-017 (or mark `drop`). No runtime impact — the current installer remains in place until a future implementation issue replaces it.
+
+---
+
+### ISSUE-018: Over-engineering/simplicity review axis (ponytail benchmark)
+
+> Benchmarked from [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail) (2026-06-22). The kit's review pipeline audits correctness, security, UI, a11y, and Figma fidelity — but has **no axis for over-engineering / minimal-code**. The kit's own TDD + Figma + multi-auditor structure is biased toward *adding* code, so a counterweight that flags unnecessary complexity is the missing dimension. ponytail's `/ponytail-review` proves the format works as a single compact pass.
+
+- Track: platform
+- UI: false
+- Platform: web
+- Manual: false
+- Spec-Required: false
+- Spec:
+- PRD-Ref: none (kit self-development; ponytail benchmark, conversation 2026-06-22)
+- Priority: P1
+- Estimate: 1d
+- Status: backlog
+- Owner:
+- Branch:
+- GH-Issue:
+- PR:
+- Depends-On: none
+
+#### Goal
+`reviewer` produces a dedicated **Over-Engineering** finding set (alongside Code Review / Security), and `/review` surfaces it in `docs/review_notes/$ARGUMENTS.md`, so PRs are graded on minimality as a first-class axis — not just correctness.
+
+#### Scope (In/Out)
+- In:
+  - Add an "Over-Engineering" checklist section to `agents/reviewer.md` using ponytail's tag taxonomy: **delete** (dead/speculative), **stdlib** (reinvented stdlib), **native** (dep doing the platform's job), **yagni** (abstraction with one impl), **shrink** (same logic, fewer lines).
+  - One-line-per-finding output format: `path:line: <tag> <what to cut> → <replacement>`, ending with net removable LOC; emit "Lean already. Ship." when nothing to cut.
+  - Add an **Over-Engineering** section to the review_notes output contract in `skills/review/SKILL.md.tmpl` (regenerate SKILL.md via `gen_skills.py`).
+  - Update `templates/review_notes.md` and (if present) `templates/review_lessons.md` to carry the new axis; allow review_lessons classification to include an `Over-Engineering` category.
+- Out:
+  - Auto-applying simplifications (reviewer still only fixes clear bugs per its existing NEVER-rewrite rule; over-engineering findings are reported, not auto-cut, unless trivial).
+  - A standalone `/simplify`-style skill (Claude Code already ships one; this is the *pipeline* axis, not an ad-hoc command).
+  - Quantitative LOC telemetry (that's ISSUE-020-adjacent / future).
+
+#### Acceptance Criteria (DoD)
+- [ ] Given a PR with a speculative abstraction used once, when `/review` runs, then the review notes contain a `yagni` finding naming the file:line and a concrete replacement.
+- [ ] Given a PR that reimplements a stdlib helper, when reviewed, then a `stdlib` finding is emitted.
+- [ ] Given a genuinely lean PR, when reviewed, then the Over-Engineering section reads "Lean already. Ship." (no false-positive padding).
+- [ ] Given the regenerated `skills/review/SKILL.md`, when diffed against the template, then it is in sync (gen_skills.py produces no further changes).
+- [ ] Given `agents/reviewer.md`, when read, then the new axis does not override the existing "NEVER rewrite/refactor during review" rule — findings are reported with severity, fixes limited to clear bugs.
+
+#### Implementation Notes
+- Reuse ponytail's exact audit phrasing as the seed prompt; adapt "L<line>" to the kit's `path:line` convention since reviews span multiple files.
+- Keep it a **section within `reviewer`**, not a new agent — avoids another subagent hop and keeps the single-pass review contract. (Revisit only if the combined prompt degrades focus.)
+- Severity mapping: `delete`/`stdlib`/`native` of risky surface → up to Medium; pure `shrink`/`yagni` → Low/advisory. Over-engineering is rarely a merge blocker by itself.
+
+#### Tests
+- [ ] reviewer prompt change is covered by a fixture review (if the repo has agent-output fixtures) OR a doc-lint test asserting the Over-Engineering section + tag taxonomy exist in `agents/reviewer.md`.
+- [ ] `gen_skills.py` round-trip test: regenerating leaves `skills/review/SKILL.md` unchanged (template is the source of truth).
+
+#### Rollback
+Remove the Over-Engineering section from `agents/reviewer.md` and the review_notes contract, regenerate SKILL.md. Review reverts to the current 4-axis behavior.
+
+---
+
+### ISSUE-019: Decision-ladder preamble for implement developer subagent (ponytail benchmark)
+
+> Benchmarked from ponytail (2026-06-22). `skills/implement` Phase 8 says "write minimal code" but gives no operational test for *minimal*. ponytail's six-rung Decision Ladder (YAGNI → stdlib → native → installed-dep → one-line → minimal) turns "minimal" into checkable gates. It complements — does not conflict with — the kit's TDD: ponytail's own rule is "lazy code without its check is unfinished," which is exactly the kit's RED/GREEN requirement.
+
+- Track: platform
+- UI: false
+- Platform: web
+- Manual: false
+- Spec-Required: false
+- Spec:
+- PRD-Ref: none (kit self-development; ponytail benchmark, conversation 2026-06-22)
+- Priority: P2
+- Estimate: 0.5d
+- Status: backlog
+- Owner:
+- Branch:
+- GH-Issue:
+- PR:
+- Depends-On: none
+
+#### Goal
+The developer subagent (`agents/developer.md`) and the implement Phase 8 prompt carry an explicit Decision Ladder the model must walk before generating code, so implementations default to the smallest correct change.
+
+#### Scope (In/Out)
+- In:
+  - Add the six-rung ladder + over-engineering prohibitions ("no abstractions not explicitly requested", "no new dependency if avoidable", "deletion over addition") to `agents/developer.md`.
+  - Add a short "Minimality gate" note to `skills/implement/SKILL.md.tmpl` Phase 8 (Implement minimal code), regenerate SKILL.md.
+  - Preserve the existing Figma structure-source prohibition and TDD ordering verbatim — the ladder is additive, placed before "write the code".
+- Out:
+  - Any change to the test-first ordering or checkpoints.
+  - Enforcement tooling (this is prompt guidance; measurement is future work).
+  - The mobile/desktop UI developer agents (can adopt the same block in a follow-up if it proves out on `developer.md` first).
+
+#### Acceptance Criteria (DoD)
+- [ ] Given `agents/developer.md`, when read, then it contains the six-rung ladder and the over-engineering prohibitions, positioned before code generation and after the TDD/check requirement.
+- [ ] Given the regenerated `skills/implement/SKILL.md`, when diffed against the template, then it is in sync.
+- [ ] Given the new block, when read alongside the existing "Self-Review Requirements" and Figma prohibition, then there is no contradictory instruction (ladder never licenses skipping tests, validation, or Figma fidelity).
+
+#### Implementation Notes
+- Keep the wording tight — the developer prompt is already long; a 6-line ladder + 3-line prohibition list, not a lecture.
+- Explicitly carve out the ponytail exception ("laziness never extends to validation/security/a11y/explicitly-requested work") so it cannot be read as license to cut corners on trust boundaries.
+
+#### Tests
+- [ ] Doc-lint/round-trip: `gen_skills.py` regeneration leaves `skills/implement/SKILL.md` in sync; assertion that the ladder block exists in `agents/developer.md`.
+
+#### Rollback
+Remove the ladder block from `agents/developer.md` and Phase 8; regenerate SKILL.md. No behavioral dependency elsewhere.
+
+---
+
+### ISSUE-020: Tech-debt marker convention + harvester + review checkpoint (ponytail benchmark)
+
+> Benchmarked from ponytail's `/ponytail-debt` (2026-06-22). The kit has no structured convention for marking *intentionally deferred* simplifications, so deferrals become silent rot. ponytail requires each debt marker to carry a **ceiling** (the constraint that holds today) and an **upgrade trigger** (the condition that forces a revisit); markers without a trigger are flagged as silent-rot risk. This fits the kit's checkpoint philosophy: make the obligation explicit and machine-checkable.
+
+- Track: platform
+- UI: false
+- Platform: web
+- Manual: false
+- Spec-Required: false
+- Spec:
+- PRD-Ref: none (kit self-development; ponytail benchmark, conversation 2026-06-22)
+- Priority: P2
+- Estimate: 1d
+- Status: backlog
+- Owner:
+- Branch:
+- GH-Issue:
+- PR:
+- Depends-On: none
+
+#### Goal
+A documented `KIT-DEBT:` marker convention (with mandatory ceiling + upgrade trigger), a `scripts/debt_harvest.py` that produces a ledger, and a non-blocking review checkpoint that flags markers missing a trigger as silent-rot risk.
+
+#### Scope (In/Out)
+- In:
+  - Define the marker grammar (e.g. `# KIT-DEBT(ceiling=…, trigger=…): <what was simplified>`) in `docs/` (or CONTRIBUTING.md) — choose a kit-namespaced token, not `ponytail:`.
+  - `scripts/debt_harvest.py`: grep the tree (excluding `.git`, `.venv`, `node_modules`, build output), parse markers, emit a ledger (location, simplification, ceiling, trigger); flag `no-trigger` entries; print "No KIT-DEBT. Clean ledger." when empty. Mirror the existing script conventions (argparse, exit codes, stdlib-only).
+  - A `/review` checkpoint phase (`debt`) wired through `verify_checkpoint.py` that runs the harvester as a **non-blocking warning** — surfaces no-trigger markers in review notes; does not fail the build.
+  - Unit tests under `tests/` following existing patterns.
+- Out:
+  - Auto-creating issues from debt markers (possible future link to issues.md).
+  - Making the checkpoint blocking (start advisory; promote later only if it earns it).
+  - Back-filling markers across the existing codebase.
+
+#### Acceptance Criteria (DoD)
+- [ ] Given source files with valid `KIT-DEBT(ceiling=…, trigger=…)` markers, when `debt_harvest.py` runs, then the ledger lists each with its location, ceiling, and trigger.
+- [ ] Given a marker with no `trigger=`, when harvested, then it is flagged `no-trigger` in the ledger and counted in the summary.
+- [ ] Given a clean tree, when harvested, then it prints "No KIT-DEBT. Clean ledger." and exits 0.
+- [ ] Given `/review`, when the `debt` checkpoint runs, then no-trigger markers appear as a warning in `docs/review_notes/$ARGUMENTS.md` without failing the review.
+- [ ] Given malformed markers, when harvested, then the script does not crash (reports them as malformed, exits non-zero only on its own usage error, not on content).
+
+#### Implementation Notes
+- Reuse the excludes and grep approach already used elsewhere in `scripts/`; keep it stdlib-only (consistent with the kit's pyyaml-is-the-only-hard-dep stance).
+- Wire the checkpoint via the existing `verify_checkpoint.py --skill review --phase debt` dispatch so the SKILL template stays a single prefix-matchable command.
+- Keep it advisory first — a blocking debt gate on a young convention would just train people to omit markers.
+
+#### Tests
+- [ ] `debt_harvest.py`: valid markers parsed; no-trigger flagged; clean tree message; malformed markers handled.
+- [ ] `verify_checkpoint.py` review/debt phase returns warning (exit 0) and writes the ledger summary where review notes can pick it up.
+
+#### Rollback
+Delete `scripts/debt_harvest.py`, remove the `debt` checkpoint phase and the convention doc. No runtime dependency — markers are inert comments if the harvester is gone.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ testpaths = ["tests"]
 pythonpath = ["."]
 asyncio_mode = "strict"
 
+[tool.coverage.run]
+# Benchmark fixtures, captured agent outputs, and one-shot scorers are
+# demonstration data, not shipped kit code — exclude from the coverage gate.
+omit = ["benchmarks/*"]
+
 [dependency-groups]
 dev = [
     "locust>=2.43.4",

--- a/scripts/debt_harvest.py
+++ b/scripts/debt_harvest.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Harvest KIT-DEBT markers into a tracked ledger.
+
+A KIT-DEBT marker records an *intentionally deferred* simplification so it
+becomes an explicit, tracked obligation rather than silent rot. Convention:
+
+    # KIT-DEBT(ceiling=<constraint that holds today>, trigger=<condition to revisit>): <what was simplified>
+    // KIT-DEBT(ceiling=..., trigger=...): ...
+
+This script greps the tree (excluding VCS/venv/build dirs), parses every
+marker, and prints a ledger. Markers missing a `trigger=` are flagged
+`no-trigger` — they are the silent-rot risk ("later means never"). Markers
+that can't be parsed into the param form are flagged `malformed` (the script
+never crashes on them).
+
+Exit codes:
+    0  ran successfully (clean tree OR debt found — this is a ledger, not a gate)
+    2  usage error (e.g. path does not exist)
+
+Usage:
+    python3 scripts/debt_harvest.py                 # scan repo root
+    python3 scripts/debt_harvest.py --path some/dir  # scan a subtree
+    python3 scripts/debt_harvest.py --json           # machine-readable ledger
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+MARKER_TOKEN = "KIT-DEBT"
+
+# Directories never worth scanning. Pruned in-place during the walk.
+EXCLUDE_DIRS = {
+    ".git", ".venv", "venv", "node_modules", "__pycache__", ".pytest_cache",
+    ".mypy_cache", ".ruff_cache", "dist", "build", ".tox", ".idea", ".vscode",
+    "figma-export", ".claude-kit",
+}
+
+# `# KIT-DEBT(...)?: description` or `// KIT-DEBT(...)?: description`.
+# The params group and the leading colon are both optional so malformed
+# markers are still captured (and then classified as malformed/no-trigger).
+_MARKER_RE = re.compile(
+    r"(?:#|//)\s*" + re.escape(MARKER_TOKEN) + r"\b\s*(?:\(([^)]*)\))?\s*:?\s*(.*)$"
+)
+_CEILING_RE = re.compile(r"ceiling\s*=\s*([^,]+?)\s*(?:,|$)")
+_TRIGGER_RE = re.compile(r"trigger\s*=\s*([^,]+?)\s*(?:,|$)")
+
+
+def _classify(params: str | None, trigger: str | None) -> str:
+    """Return the marker status: ok | no-trigger | malformed."""
+    if params is None:
+        # No parens at all — can't carry a ceiling or trigger.
+        return "malformed"
+    if trigger is None:
+        return "no-trigger"
+    return "ok"
+
+
+def parse_line(line: str) -> dict | None:
+    """Parse a single source line into a marker dict, or None if no marker."""
+    if MARKER_TOKEN not in line:
+        return None
+    m = _MARKER_RE.search(line)
+    if not m:
+        # Token appears only as prose / a string literal, not in `#`/`//`
+        # comment form (e.g. this script's own source). Not a debt marker.
+        return None
+    params, desc = m.group(1), m.group(2).strip()
+    ceiling = trigger = None
+    if params is not None:
+        cm = _CEILING_RE.search(params)
+        tm = _TRIGGER_RE.search(params)
+        ceiling = cm.group(1).strip() if cm else None
+        trigger = tm.group(1).strip() if tm else None
+    return {
+        "params": params,
+        "ceiling": ceiling,
+        "trigger": trigger,
+        "description": desc,
+        "status": _classify(params, trigger),
+    }
+
+
+def harvest(root: Path) -> list[dict]:
+    """Walk `root` and collect every KIT-DEBT marker with its location."""
+    entries: list[dict] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS]
+        for name in filenames:
+            fpath = Path(dirpath) / name
+            try:
+                text = fpath.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue  # binary or unreadable — skip silently
+            if MARKER_TOKEN not in text:
+                continue
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                marker = parse_line(line)
+                if marker is None:
+                    continue
+                marker["file"] = str(fpath.relative_to(root))
+                marker["line"] = lineno
+                entries.append(marker)
+    entries.sort(key=lambda e: (e["file"], e["line"]))
+    return entries
+
+
+def render_text(entries: list[dict]) -> str:
+    """Render the human-readable ledger."""
+    if not entries:
+        return "No KIT-DEBT. Clean ledger."
+
+    lines: list[str] = ["KIT-DEBT ledger", "=" * 60]
+    for e in entries:
+        flag = "" if e["status"] == "ok" else f"  [{e['status'].upper()}]"
+        lines.append(f"{e['file']}:{e['line']}{flag}")
+        lines.append(f"    simplification: {e['description'] or '—'}")
+        lines.append(f"    ceiling:        {e['ceiling'] or '—'}")
+        lines.append(f"    trigger:        {e['trigger'] or '—'}")
+    no_trigger = sum(1 for e in entries if e["status"] == "no-trigger")
+    malformed = sum(1 for e in entries if e["status"] == "malformed")
+    lines.append("-" * 60)
+    lines.append(
+        f"total: {len(entries)}  |  no-trigger (silent-rot risk): {no_trigger}"
+        f"  |  malformed: {malformed}"
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Harvest KIT-DEBT markers into a ledger.")
+    parser.add_argument(
+        "--path", default=".", help="Root directory to scan (default: current dir)."
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Emit the ledger as JSON."
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.path)
+    if not root.exists():
+        print(f"ERROR: path does not exist: {root}", file=sys.stderr)
+        return 2
+
+    entries = harvest(root)
+
+    if args.json:
+        no_trigger = sum(1 for e in entries if e["status"] == "no-trigger")
+        malformed = sum(1 for e in entries if e["status"] == "malformed")
+        payload = {
+            "total": len(entries),
+            "no_trigger": no_trigger,
+            "malformed": malformed,
+            "entries": entries,
+        }
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        print(render_text(entries))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_checkpoint.py
+++ b/scripts/verify_checkpoint.py
@@ -1044,7 +1044,7 @@ def verify_review_checkout(issue_id: str, **_) -> bool:
 
 
 def verify_review_review(issue_id: str, **_) -> bool:
-    """review_notes.md has Code Review and Security Findings as markdown headers."""
+    """review_notes.md has Code Review, Security Findings, and Over-Engineering headers."""
     wt_path = _find_worktree_path(issue_id)
     if not wt_path:
         print(f"FAIL: no worktree found for {issue_id}")
@@ -1065,6 +1065,8 @@ def verify_review_review(issue_id: str, **_) -> bool:
         missing.append("Code Review")
     if not re.search(r"^#{1,6}\s+.*Security Findings", content, re.MULTILINE):
         missing.append("Security Findings")
+    if not re.search(r"^#{1,6}\s+.*Over-Engineering", content, re.MULTILINE):
+        missing.append("Over-Engineering")
 
     if missing:
         print(f"FAIL: review_notes.md missing header sections: {', '.join(missing)}")
@@ -1406,6 +1408,32 @@ def verify_review_figma_compliance(issue_id: str, **_) -> bool:
     return False
 
 
+def verify_review_debt(issue_id: str, **_) -> bool:
+    """Harvest KIT-DEBT markers — NON-BLOCKING advisory.
+
+    Always returns True (a debt ledger is informational, not a gate). Surfaces
+    markers missing an upgrade `trigger=` as silent-rot warnings the reviewer
+    should record in review notes. Scans the worktree if one exists, else the
+    main repo root.
+    """
+    wt_path = _find_worktree_path(issue_id)
+    scan_path = wt_path or str(_repo_root())
+
+    result = _run(
+        ["python3", str(Path(__file__).resolve().parent / "debt_harvest.py"),
+         "--path", scan_path],
+        timeout=30,
+    )
+    if result.stdout:
+        for line in result.stdout.strip().splitlines():
+            print(f"  {line}")
+    if result.returncode != 0:
+        # Only a usage error (bad path) — non-blocking by design.
+        print("WARN: debt_harvest.py could not run — skipping debt ledger (non-blocking)")
+    print("PASS: debt ledger harvested (advisory — no-trigger markers are silent-rot risks)")
+    return True
+
+
 def verify_review_test(issue_id: str, **_) -> bool:
     """pytest exits 0 (inside worktree)."""
     return verify_implement_test(issue_id)
@@ -1690,6 +1718,7 @@ VERIFIERS = {
     ("review", "structural-match"): verify_review_structural_match,
     ("review", "layout"): verify_review_layout,
     ("review", "test-quality"): verify_review_test_quality,
+    ("review", "debt"): verify_review_debt,
     ("review", "test"): verify_review_test,
     ("review", "push"): verify_review_push,
     ("ship", "checks"): verify_ship_checks,

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -306,6 +306,11 @@ The script reads `issues.md`, detects sprint mode via `KIT_SPRINT_MODE=1`, scans
 8) **Implement minimal code** inside `$WT/`.
    Write the minimum code needed to make all tests pass. Follow existing project patterns.
 
+   **Minimality gate — walk the Decision Ladder before generating code** (the developer subagent enforces this; the orchestrator must not write prompts that contradict it):
+   1. Does this need to exist? (YAGNI) → 2. Does stdlib cover it? → 3. Native platform/framework feature? → 4. Already-installed dependency? → 5. Can it be one line? → 6. Only then write the minimum that works.
+   Prohibitions: no abstraction with a single implementation, no avoidable new dependency, no unrequested boilerplate — deletion over addition, fewest files possible.
+   **This never overrides safety**: it does not license skipping the TDD tests, input validation, error handling, security, accessibility, or Figma/design fidelity. Minimal means *less code*, not *less correct*.
+
    **If Figma data exists** (`figma-export/` directory present):
    - **BEFORE writing any code**, read `prototype/screens/*.html` — this is your visual target
    - Read `figma-export/figma_styles.css` — import this CSS directly

--- a/skills/implement/SKILL.md.tmpl
+++ b/skills/implement/SKILL.md.tmpl
@@ -233,6 +233,11 @@ The script reads `issues.md`, detects sprint mode via `KIT_SPRINT_MODE=1`, scans
 8) **Implement minimal code** inside `$WT/`.
    Write the minimum code needed to make all tests pass. Follow existing project patterns.
 
+   **Minimality gate — walk the Decision Ladder before generating code** (the developer subagent enforces this; the orchestrator must not write prompts that contradict it):
+   1. Does this need to exist? (YAGNI) → 2. Does stdlib cover it? → 3. Native platform/framework feature? → 4. Already-installed dependency? → 5. Can it be one line? → 6. Only then write the minimum that works.
+   Prohibitions: no abstraction with a single implementation, no avoidable new dependency, no unrequested boilerplate — deletion over addition, fewest files possible.
+   **This never overrides safety**: it does not license skipping the TDD tests, input validation, error handling, security, accessibility, or Figma/design fidelity. Minimal means *less code*, not *less correct*.
+
    **If Figma data exists** (`figma-export/` directory present):
    - **BEFORE writing any code**, read `prototype/screens/*.html` — this is your visual target
    - Read `figma-export/figma_styles.css` — import this CSS directly

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -101,9 +101,10 @@ Steps:
    - `docs/architecture.md` — if exists (for conformance checks)
    - For UI issues, also read in parallel: `docs/design_system.md` (or `design_system_mobile.md`), `docs/copy_guide.md`, `docs/interactions.md` (or `interactions_mobile.md`), `docs/wireframes.md` (or `wireframes_mobile.md`).
 
-   Ask reviewer subagent to perform code review + security audit:
+   Ask reviewer subagent to perform code review + security audit + over-engineering audit:
    - Code quality: correctness, edge cases, maintainability, complexity, test coverage.
    - Security: injection, auth issues, hardcoded secrets, dependency CVEs, input validation, XSS, misconfiguration.
+   - Over-engineering (minimality axis): scan the diff for unnecessary complexity, tagging each finding `delete` / `stdlib` / `native` / `yagni` / `shrink`, one line per finding (`path:line: <tag> <what to cut> → <replacement>`), ending with net removable lines — or `Lean already. Ship.` if nothing to cut. This axis never overrides safety (validation, error handling, security, a11y, explicitly-requested work).
    - Pass gathered context (review_lessons, architecture) so the reviewer can identify recurring patterns.
 
 3.5) **Figma compliance check** (auto-skips if no Figma data) — **runs BEFORE UI review to ensure Figma fidelity first**:
@@ -190,9 +191,17 @@ Steps:
 > Run: `bash scripts/checkpoint.sh --skill review --phase test-quality --issue $ARGUMENTS`
 > If exit code ≠ 0: STOP immediately and report the failure. Do NOT proceed.
 
+4.7) **Tech-debt ledger** (advisory — harvests `KIT-DEBT` markers):
+
+> **CHECKPOINT — advisory (non-blocking)**
+> Run: `bash scripts/checkpoint.sh --skill review --phase debt --issue $ARGUMENTS`
+> Always exits 0. Lists every `KIT-DEBT(ceiling=…, trigger=…)` marker; flags markers missing a `trigger=` as **silent-rot risk**.
+> Record any `no-trigger` markers in the Over-Engineering / follow-ups section of the review notes so deferrals don't become permanent. Does NOT block the review.
+
 5) Update docs/review_notes/$ARGUMENTS.md (inside `$WT/`) with sections:
    - **Code Review**: findings, changes, follow-ups.
    - **Security Findings**: severity-classified list with remediation steps.
+   - **Over-Engineering**: tagged findings (`delete`/`stdlib`/`native`/`yagni`/`shrink`), one line each, ending with net removable lines — or `Lean already. Ship.`
    - **UI Review** (from ui-reviewer, if applicable): State Coverage, Copy, Tokens, Accessibility.
    - **Design Audit** (from design-auditor, if applicable): Token Consistency, Component Completeness, Philosophy Compliance.
    - **Accessibility Audit** (from a11y-auditor, if applicable): WCAG 2.1 AA findings and remediation.

--- a/skills/review/SKILL.md.tmpl
+++ b/skills/review/SKILL.md.tmpl
@@ -28,9 +28,10 @@ Steps:
    - `docs/architecture.md` — if exists (for conformance checks)
    - For UI issues, also read in parallel: `docs/design_system.md` (or `design_system_mobile.md`), `docs/copy_guide.md`, `docs/interactions.md` (or `interactions_mobile.md`), `docs/wireframes.md` (or `wireframes_mobile.md`).
 
-   Ask reviewer subagent to perform code review + security audit:
+   Ask reviewer subagent to perform code review + security audit + over-engineering audit:
    - Code quality: correctness, edge cases, maintainability, complexity, test coverage.
    - Security: injection, auth issues, hardcoded secrets, dependency CVEs, input validation, XSS, misconfiguration.
+   - Over-engineering (minimality axis): scan the diff for unnecessary complexity, tagging each finding `delete` / `stdlib` / `native` / `yagni` / `shrink`, one line per finding (`path:line: <tag> <what to cut> → <replacement>`), ending with net removable lines — or `Lean already. Ship.` if nothing to cut. This axis never overrides safety (validation, error handling, security, a11y, explicitly-requested work).
    - Pass gathered context (review_lessons, architecture) so the reviewer can identify recurring patterns.
 
 3.5) **Figma compliance check** (auto-skips if no Figma data) — **runs BEFORE UI review to ensure Figma fidelity first**:
@@ -117,9 +118,17 @@ Steps:
 > Run: `bash scripts/checkpoint.sh --skill review --phase test-quality --issue $ARGUMENTS`
 > If exit code ≠ 0: STOP immediately and report the failure. Do NOT proceed.
 
+4.7) **Tech-debt ledger** (advisory — harvests `KIT-DEBT` markers):
+
+> **CHECKPOINT — advisory (non-blocking)**
+> Run: `bash scripts/checkpoint.sh --skill review --phase debt --issue $ARGUMENTS`
+> Always exits 0. Lists every `KIT-DEBT(ceiling=…, trigger=…)` marker; flags markers missing a `trigger=` as **silent-rot risk**.
+> Record any `no-trigger` markers in the Over-Engineering / follow-ups section of the review notes so deferrals don't become permanent. Does NOT block the review.
+
 5) Update docs/review_notes/$ARGUMENTS.md (inside `$WT/`) with sections:
    - **Code Review**: findings, changes, follow-ups.
    - **Security Findings**: severity-classified list with remediation steps.
+   - **Over-Engineering**: tagged findings (`delete`/`stdlib`/`native`/`yagni`/`shrink`), one line each, ending with net removable lines — or `Lean already. Ship.`
    - **UI Review** (from ui-reviewer, if applicable): State Coverage, Copy, Tokens, Accessibility.
    - **Design Audit** (from design-auditor, if applicable): Token Consistency, Component Completeness, Philosophy Compliance.
    - **Accessibility Audit** (from a11y-auditor, if applicable): WCAG 2.1 AA findings and remediation.

--- a/templates/review_notes.md
+++ b/templates/review_notes.md
@@ -34,3 +34,19 @@ Severity: Critical | High | Medium | Low
 ### Summary
 - Critical/High: [count]
 - Medium/Low: [count]
+
+## Over-Engineering
+
+### Findings
+
+<!-- One line per finding:
+[path:line]: [tag] [what to cut] → [replacement]
+
+Tags: delete (dead/speculative) | stdlib (reinvented stdlib) | native (dep doing the platform's job) | yagni (abstraction with one impl) | shrink (same logic, fewer lines)
+
+Minimality axis only — NOT correctness. Never recommend cutting validation, error handling, security, accessibility, or explicitly-requested work.
+If nothing to cut, write exactly: Lean already. Ship.
+-->
+
+### Summary
+- Net removable lines: [count]

--- a/tests/test_debt_harvest.py
+++ b/tests/test_debt_harvest.py
@@ -1,0 +1,90 @@
+"""Unit tests for scripts/debt_harvest.py."""
+
+from pathlib import Path
+
+from scripts.debt_harvest import harvest, parse_line, render_text
+
+
+def test_parse_valid_marker_extracts_ceiling_and_trigger():
+    m = parse_line(
+        "# KIT-DEBT(ceiling=<=100 items, trigger=list grows unbounded): linear scan"
+    )
+    assert m is not None
+    assert m["status"] == "ok"
+    assert m["ceiling"] == "<=100 items"
+    assert m["trigger"] == "list grows unbounded"
+    assert m["description"] == "linear scan"
+
+
+def test_parse_slash_comment_marker():
+    m = parse_line("    // KIT-DEBT(ceiling=single region, trigger=multi-region): endpoint")
+    assert m is not None
+    assert m["status"] == "ok"
+    assert m["trigger"] == "multi-region"
+
+
+def test_marker_without_trigger_is_flagged_no_trigger():
+    m = parse_line("# KIT-DEBT(ceiling=small input): no upgrade path here")
+    assert m is not None
+    assert m["status"] == "no-trigger"
+    assert m["trigger"] is None
+    assert m["ceiling"] == "small input"
+
+
+def test_marker_without_params_is_malformed():
+    m = parse_line("# KIT-DEBT: just a vague note")
+    assert m is not None
+    assert m["status"] == "malformed"
+
+
+def test_line_without_marker_returns_none():
+    assert parse_line("# a perfectly ordinary comment") is None
+    assert parse_line("x = 1  # TODO: not a debt marker") is None
+
+
+def test_harvest_clean_tree(tmp_path: Path):
+    (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
+    entries = harvest(tmp_path)
+    assert entries == []
+    assert render_text(entries) == "No KIT-DEBT. Clean ledger."
+
+
+def test_harvest_collects_and_locates_markers(tmp_path: Path):
+    (tmp_path / "svc.py").write_text(
+        "def f():\n"
+        "    pass  # KIT-DEBT(ceiling=N<100, trigger=N grows): linear scan\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "web.js").write_text(
+        "// KIT-DEBT(ceiling=one region): hardcoded url\n",
+        encoding="utf-8",
+    )
+    entries = harvest(tmp_path)
+    assert len(entries) == 2
+    by_file = {e["file"]: e for e in entries}
+    assert by_file["svc.py"]["line"] == 2
+    assert by_file["svc.py"]["status"] == "ok"
+    assert by_file["web.js"]["status"] == "no-trigger"
+    text = render_text(entries)
+    assert "no-trigger (silent-rot risk): 1" in text
+
+
+def test_harvest_excludes_vendor_dirs(tmp_path: Path):
+    vendor = tmp_path / "node_modules" / "pkg"
+    vendor.mkdir(parents=True)
+    (vendor / "index.js").write_text(
+        "// KIT-DEBT(trigger=x): should be ignored\n", encoding="utf-8"
+    )
+    entries = harvest(tmp_path)
+    assert entries == []
+
+
+def test_harvest_skips_binary_files(tmp_path: Path):
+    # A binary file containing the token bytes must not crash the walk.
+    (tmp_path / "blob.bin").write_bytes(b"\x00\x01KIT-DEBT\xff\xfe")
+    (tmp_path / "ok.py").write_text(
+        "# KIT-DEBT(ceiling=a, trigger=b): real one\n", encoding="utf-8"
+    )
+    entries = harvest(tmp_path)
+    assert len(entries) == 1
+    assert entries[0]["file"] == "ok.py"

--- a/tests/test_verify_checkpoint.py
+++ b/tests/test_verify_checkpoint.py
@@ -665,7 +665,8 @@ class TestVerifyReviewReview:
         notes_dir = tmp_path / "wt" / "issue" / "issue-001-slug" / "docs"
         notes_dir.mkdir(parents=True)
         (notes_dir / "review_notes.md").write_text(
-            "# Code Review\nFindings here.\n\n# Security Findings\nNone.\n"
+            "# Code Review\nFindings here.\n\n# Security Findings\nNone.\n\n"
+            "# Over-Engineering\nLean already. Ship.\n"
         )
 
         with patch.object(vc, "_run", return_value=_mock_run(0, stdout=wt_stdout)):
@@ -676,7 +677,8 @@ class TestVerifyReviewReview:
         notes_dir = tmp_path / "wt" / "issue" / "issue-001-slug" / "docs"
         notes_dir.mkdir(parents=True)
         (notes_dir / "review_notes.md").write_text(
-            "## Code Review\nFindings.\n\n## Security Findings\nNone.\n"
+            "## Code Review\nFindings.\n\n## Security Findings\nNone.\n\n"
+            "## Over-Engineering\nLean already. Ship.\n"
         )
 
         with patch.object(vc, "_run", return_value=_mock_run(0, stdout=wt_stdout)):
@@ -689,11 +691,24 @@ class TestVerifyReviewReview:
         notes_dir = tmp_path / "wt" / "issue" / "issue-001-slug" / "docs" / "review_notes"
         notes_dir.mkdir(parents=True)
         (notes_dir / "ISSUE-001.md").write_text(
-            "# Code Review\nFindings.\n\n# Security Findings\nNone.\n"
+            "# Code Review\nFindings.\n\n# Security Findings\nNone.\n\n"
+            "# Over-Engineering\nLean already. Ship.\n"
         )
 
         with patch.object(vc, "_run", return_value=_mock_run(0, stdout=wt_stdout)):
             assert vc.verify_review_review("ISSUE-001") is True
+
+    def test_fail_missing_over_engineering_section(self, tmp_path):
+        """Code Review + Security present but Over-Engineering missing must fail."""
+        wt_stdout = f"worktree {tmp_path}/wt/issue/issue-001-slug\n"
+        notes_dir = tmp_path / "wt" / "issue" / "issue-001-slug" / "docs"
+        notes_dir.mkdir(parents=True)
+        (notes_dir / "review_notes.md").write_text(
+            "# Code Review\nFindings.\n\n# Security Findings\nNone.\n"
+        )
+
+        with patch.object(vc, "_run", return_value=_mock_run(0, stdout=wt_stdout)):
+            assert vc.verify_review_review("ISSUE-001") is False
 
     def test_fail_missing_sections(self, tmp_path):
         wt_stdout = f"worktree {tmp_path}/wt/issue/issue-001-slug\n"


### PR DESCRIPTION
Benchmarks [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail) and adds the **code-minimality dimension** the kit's implement/review pipeline lacked. Three issues implemented + an A/B measurement harness with honest results.

## What changed
- **ISSUE-018 — over-engineering review axis**: `agents/reviewer.md` gains an Over-Engineering checklist (`delete/stdlib/native/yagni/shrink`); review SKILL + `templates/review_notes.md` + the review-review checkpoint now require the section.
- **ISSUE-019 — decision-ladder preamble**: `agents/developer.md` gains the six-rung ladder + over-engineering prohibitions before code generation; implement Phase 8 carries the minimality gate. Safety carve-out (TDD/validation/security/Figma) preserved.
- **ISSUE-020 — tech-debt marker + harvester**: `scripts/debt_harvest.py` (`KIT-DEBT` ledger; no-trigger = silent-rot flag) + 9 unit tests; non-blocking review `debt` checkpoint; convention in CONTRIBUTING.md.

## Measurement (`benchmarks/`, model held constant at sonnet across arms)
**018 — review axis (6 fixtures):** recall *saturated* at 8/8 on blatant fixtures (baseline's complexity check caught the same lines). The axis's measured value is elsewhere:
- tag classification **0% → 88%**
- **direction flip**: baseline recommended *adding* a Notifier ABC/Protocol where treatment said `delete`.
- 0/2 false positives on lean controls.
- *Limitation logged*: fixtures too easy to show a recall delta.

**019 — decision ladder (3 tasks):** logical LOC **102 → 25 (75% reduction)**, concentrated where baseline over-built (taskC 37→5); input validation preserved in every treatment impl.

**020:** correctness, not perf — 9/9 unit tests.

> Caveats (in `benchmarks/README.md`): small N, hand-authored fixtures, single-shot runs, author-labelled ground truth. Directional, not statistical.

## Testing
- `tests/test_debt_harvest.py` 9/9; verify_checkpoint review suite green; `gen_skills --dry-run` fresh; `validate_issues` 21/21.
- The 23 pack-manifest/install failures seen locally were **missing PyYAML in the dev venv** (CI installs it; all 36 pass once installed) — filed as **ISSUE-021** (tests should `importorskip("yaml")`).
- Coverage gate: `benchmarks/` omitted (demonstration data, not shipped code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)