### PR TITLE
fix(tests): skip pyyaml-dependent tests when PyYAML absent (ISSUE-021)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,13 @@ becomes a *tracked* obligation instead of silent rot. Every marker must carry a
 
 ## Running Tests
 
+Install the dev extras first so optional test dependencies (e.g. PyYAML, used by
+the pack-manifest tests) are present — otherwise those tests **skip** with a reason:
+
+```bash
+pip install -e '.[dev]'        # or: uv sync
+```
+
 ```bash
 python3 -m pytest              # all tests
 python3 -m pytest -x           # stop on first failure

--- a/issues.md
+++ b/issues.md
@@ -24,10 +24,6 @@
 - [ ] ISSUE-015: Adopt agent effort tiers + refresh model references _(track: platform, P2, 1d)_
 - [ ] ISSUE-016: Worktree/session lifecycle hooks — auto-freeze + run/ cleanup _(track: platform, P2, 1d)_
 - [ ] ISSUE-017: Migrate kit packaging to Claude Code plugin system _(track: platform, P1, 1.5d — spec)_
-- [ ] ISSUE-018: Over-engineering/simplicity review axis (ponytail benchmark) _(track: platform, P1, 1d)_
-- [ ] ISSUE-019: Decision-ladder preamble for implement developer subagent (ponytail benchmark) _(track: platform, P2, 0.5d)_
-- [ ] ISSUE-020: Tech-debt marker convention + harvester + review checkpoint (ponytail benchmark) _(track: platform, P2, 1d)_
-- [ ] ISSUE-021: PyYAML-dependent tests should skip cleanly when the dep is absent _(track: platform, P2, 0.5d)_
 
 ### Doing
 
@@ -47,6 +43,10 @@
 - [x] ISSUE-011: Kill WebFetch reference fabrication — image-grounded references only _(track: platform, P1, 0.5d)_
 - [x] ISSUE-012: Reference Anchor tuning — 2-3 strong cues + 1 literal quote _(track: platform, P2, 0.5d)_
 - [x] ISSUE-013: Consolidate ui-reviewer / design-auditor agents — sharpen role boundaries _(track: platform, P2, 1d)_
+- [x] ISSUE-018: Over-engineering/simplicity review axis (ponytail benchmark) _(track: platform, P1, 1d)_
+- [x] ISSUE-019: Decision-ladder preamble for implement developer subagent (ponytail benchmark) _(track: platform, P2, 0.5d)_
+- [x] ISSUE-020: Tech-debt marker convention + harvester + review checkpoint (ponytail benchmark) _(track: platform, P2, 1d)_
+- [x] ISSUE-021: PyYAML-dependent tests should skip cleanly when the dep is absent _(track: platform, P2, 0.5d)_
 
 ### Drop
 
@@ -1105,11 +1105,11 @@ Abandon SPEC-017 (or mark `drop`). No runtime impact — the current installer r
 - PRD-Ref: none (kit self-development; ponytail benchmark, conversation 2026-06-22)
 - Priority: P1
 - Estimate: 1d
-- Status: backlog
+- Status: done
 - Owner:
-- Branch:
+- Branch: chore/issues-ponytail-benchmark
 - GH-Issue:
-- PR:
+- PR: #36
 - Depends-On: none
 
 #### Goal
@@ -1160,11 +1160,11 @@ Remove the Over-Engineering section from `agents/reviewer.md` and the review_not
 - PRD-Ref: none (kit self-development; ponytail benchmark, conversation 2026-06-22)
 - Priority: P2
 - Estimate: 0.5d
-- Status: backlog
+- Status: done
 - Owner:
-- Branch:
+- Branch: chore/issues-ponytail-benchmark
 - GH-Issue:
-- PR:
+- PR: #36
 - Depends-On: none
 
 #### Goal
@@ -1210,11 +1210,11 @@ Remove the ladder block from `agents/developer.md` and Phase 8; regenerate SKILL
 - PRD-Ref: none (kit self-development; ponytail benchmark, conversation 2026-06-22)
 - Priority: P2
 - Estimate: 1d
-- Status: backlog
+- Status: done
 - Owner:
-- Branch:
+- Branch: chore/issues-ponytail-benchmark
 - GH-Issue:
-- PR:
+- PR: #36
 - Depends-On: none
 
 #### Goal
@@ -1265,11 +1265,11 @@ Delete `scripts/debt_harvest.py`, remove the `debt` checkpoint phase and the con
 - PRD-Ref: none (kit self-development; discovered during ISSUE-018~020, conversation 2026-06-22)
 - Priority: P2
 - Estimate: 0.5d
-- Status: backlog
+- Status: done
 - Owner:
-- Branch:
+- Branch: issue/ISSUE-021-pyyaml-skip
 - GH-Issue:
-- PR:
+- PR: #37
 - Depends-On: none
 
 #### Goal

--- a/tests/test_install_packs.py
+++ b/tests/test_install_packs.py
@@ -12,6 +12,14 @@ from pathlib import Path
 
 import pytest
 
+# Pack install parses manifest YAML, which requires PyYAML (a dev/CI dependency,
+# not a hard runtime dep — see #33). Skip cleanly rather than fail when running a
+# bare `pytest` without dev extras installed.
+pytest.importorskip(
+    "yaml",
+    reason="PyYAML not installed — run `pip install -e '.[dev]'` or `uv sync`",
+)
+
 from scripts.install_packs import (
     discover_packs,
     resolve_pack_selection,

--- a/tests/test_validate_pack_manifest.py
+++ b/tests/test_validate_pack_manifest.py
@@ -4,6 +4,14 @@ from pathlib import Path
 
 import pytest
 
+# Pack-manifest parsing requires PyYAML (a dev/CI dependency, not a hard runtime
+# dep — see #33). Skip cleanly rather than fail with a confusing wall of errors
+# when running a bare `pytest` without dev extras installed.
+pytest.importorskip(
+    "yaml",
+    reason="PyYAML not installed — run `pip install -e '.[dev]'` or `uv sync`",
+)
+
 from scripts.validate_pack_manifest import main, validate_packs
 
 


### PR DESCRIPTION
Closes ISSUE-021.

## Problem
On a venv without PyYAML, `tests/test_validate_pack_manifest.py` and `tests/test_install_packs.py` produced **23 hard failures** (the #33 lazy-fail guard: `PyYAML is required for pack manifest parsing`), indistinguishable from a real regression. CI is unaffected (it installs pyyaml), but a bare local `pytest` is misleading — this cost time during the ISSUE-018~020 work.

## Fix
- Module-level `pytest.importorskip("yaml", reason=...)` in both test files (the canonical pytest idiom for an optional test dep). PyYAML stays a dev/CI dep, **not** a hard runtime dep (#33 is intentional).
- CONTRIBUTING "Running Tests" documents `pip install -e '.[dev]'` / `uv sync`.

## Verification
- yaml **absent** → `2 skipped, 0 failed`
- yaml **present** → `36 passed` (no behavior change)

## Also
Board cleanup: ISSUE-018/019/020 marked done (merged in #36); ISSUE-021 marked done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)