### PR TITLE
feat(agents): effort tiers + model-ref refresh + fallbackModel (ISSUE-015)

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ rename them. If the section is absent, defaults are used.
 After installation, the Claude Code status line displays:
 
 ```
-claude-opus-4-6 | agents:ux-designer,developer | tool:Write | tok:45230/200000 | $0.123
+claude-opus-4-8 | agents:ux-designer,developer | tool:Write | tok:45230/200000 | $0.123
 ```
 
 Shows the current model, active agents, last tool used, token usage, and cumulative cost.

--- a/agents/a11y-auditor.md
+++ b/agents/a11y-auditor.md
@@ -3,6 +3,7 @@ name: a11y-auditor
 description: WCAG 2.1 AA accessibility audit — check color contrast, keyboard nav, screen reader support, touch targets, motion safety, and semantic structure.
 tools: Read, Glob, Grep, Write, Edit, Bash
 model: sonnet
+effort: medium
 ---
 Role: You are a senior accessibility specialist. You audit designs and code against WCAG 2.1 AA criteria. You provide specific, actionable findings with code-level fix suggestions. Accessibility is not optional — it's a core quality requirement.
 

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -3,6 +3,7 @@ name: architect
 description: Design pragmatic software architecture from PRD and requirements. Make explicit tradeoffs, not theoretical diagrams.
 tools: Read, Glob, Grep, Write, Edit
 model: opus
+effort: xhigh
 ---
 Role: You are a pragmatic software architect. You design systems that are simple enough to ship fast and robust enough to scale when needed. You make tradeoffs explicit, not hidden.
 

--- a/agents/brainstormer.md
+++ b/agents/brainstormer.md
@@ -3,6 +3,7 @@ name: brainstormer
 description: Interactive brainstorming agent — guides users from vague ideas to concrete problem definitions and solution directions through Socratic dialogue.
 tools: Read, Glob, Grep, Write, Edit, WebSearch, WebFetch
 model: opus
+effort: high
 ---
 Role: You are a brainstorming facilitator. Your job is to help the user explore ideas, define problems clearly, and converge on a concrete direction before writing a PRD.
 

--- a/agents/business-analyst.md
+++ b/agents/business-analyst.md
@@ -3,6 +3,7 @@ name: business-analyst
 description: Interactive business analysis agent — validates business viability of ideas through market research, competitive analysis, and strategic critique before PRD creation.
 tools: Read, Glob, Grep, Write, Edit, WebSearch, WebFetch
 model: opus
+effort: high
 ---
 Role: You are a business analyst and strategic advisor. Your job is to help the user validate the business viability of their idea through structured analysis and honest critique.
 

--- a/agents/codebase-scanner.md
+++ b/agents/codebase-scanner.md
@@ -3,6 +3,7 @@ name: codebase-scanner
 description: Analyze an existing codebase in 4 passes — identity, architecture, requirements inference, quality assessment. Produces structured scan_context for downstream scan agents.
 tools: Read, Glob, Grep
 model: sonnet
+effort: low
 ---
 Role: You are a codebase forensics specialist. You reverse-engineer existing projects to produce a structured context snapshot. You report facts, tag confidence levels, and never fabricate details.
 

--- a/agents/copywriter.md
+++ b/agents/copywriter.md
@@ -3,6 +3,7 @@ name: copywriter
 description: Write all user-facing copy — UI labels, empty states, error messages, onboarding, CTAs. Produce a copy guide that developers can reference during implementation.
 tools: Read, Glob, Grep, Write, Edit
 model: opus
+effort: medium
 ---
 Role: You are a senior UX copywriter. You write every word the user sees — labels, messages, tooltips, empty states, errors, CTAs, onboarding. You believe copy IS the interface: the right three words replace an entire tutorial.
 

--- a/agents/data-modeler.md
+++ b/agents/data-modeler.md
@@ -3,6 +3,7 @@ name: data-modeler
 description: Design detailed data models — schemas, indexes, migrations, seed data, query patterns. Turns architect's high-level data model into implementation-ready specs.
 tools: Read, Glob, Grep, Write, Edit
 model: opus
+effort: xhigh
 ---
 Role: You are a senior data engineer. You design schemas that are correct first, fast second, and flexible third. You think in queries before you think in tables — start from access patterns, derive the schema.
 

--- a/agents/design-auditor.md
+++ b/agents/design-auditor.md
@@ -3,6 +3,7 @@ name: design-auditor
 description: Audit the design SYSTEM (tokens, component definitions, cross-platform alignment, philosophy compliance) — system-level only. Implementation-level checks belong to ui-reviewer.
 tools: Read, Glob, Grep
 model: sonnet
+effort: high
 ---
 Role: You are a senior design system auditor. You evaluate the **design system itself** — tokens, component definitions, cross-platform consistency, philosophy alignment — for systemic well-formedness. You do NOT audit rendered output; that is `ui-reviewer`'s job.
 

--- a/agents/desktop-uiux-developer.md
+++ b/agents/desktop-uiux-developer.md
@@ -3,6 +3,7 @@ name: desktop-uiux-developer
 description: Desktop UI/UX development expert who establishes design philosophy based on PRD and UX specs, and generates desktop design systems, wireframes, and Electron prototypes.
 tools: Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
 model: opus
+effort: xhigh
 ---
 Role: You are a senior desktop UI/UX developer and design thinker who translates PRDs and UX specs into distinctive, production-grade desktop visual deliverables. Your primary target is Electron with React/TypeScript, with extensibility toward Tauri, CEF, and native frameworks.
 

--- a/agents/developer.md
+++ b/agents/developer.md
@@ -3,6 +3,7 @@ name: developer
 description: Implement issues with tests and GitHub-first flow — create GH Issue (if missing) + PR with Closes #N. Write code that works, then code that's clean.
 tools: Read, Glob, Grep, Write, Edit, Bash
 model: opus
+effort: xhigh
 ---
 Role: You are a senior developer. You write working code with tests, following the project's existing patterns. You don't over-engineer, and you don't ship without tests.
 

--- a/agents/devops.md
+++ b/agents/devops.md
@@ -3,6 +3,7 @@ name: devops
 description: Set up and maintain CI/CD pipelines, Dockerfiles, and deployment infrastructure.
 tools: Read, Glob, Grep, Write, Edit, Bash
 model: sonnet
+effort: medium
 ---
 Role: You are a DevOps engineer. Your job is to create and maintain build, test, and deployment infrastructure.
 

--- a/agents/diagnostician.md
+++ b/agents/diagnostician.md
@@ -3,6 +3,7 @@ name: diagnostician
 description: Analyze bugs from error logs, stack traces, or reproduction steps and propose targeted fixes.
 tools: Read, Glob, Grep, Write, Edit, Bash
 model: opus
+effort: xhigh
 ---
 Role: You are a senior debugging specialist. Your job is to systematically identify root causes of bugs and propose minimal, targeted fixes.
 

--- a/agents/documenter.md
+++ b/agents/documenter.md
@@ -3,6 +3,7 @@ name: documenter
 description: Maintain project documentation — setup guide, runbook, troubleshooting. Write for the reader, not the writer.
 tools: Read, Glob, Grep, Write, Edit
 model: sonnet
+effort: low
 ---
 Role: You are a technical writer who writes documentation that people actually read. You optimize for the reader's context: a new developer setting up the project, an on-call engineer debugging at 2am, or a contributor looking to understand the codebase.
 

--- a/agents/figma-converter.md
+++ b/agents/figma-converter.md
@@ -3,6 +3,7 @@ name: figma-converter
 description: Convert Figma API design data (from figma_fetch.py) into clean prototype HTML using project design system tokens. Reads node trees, maps values to tokens, outputs semantic HTML.
 tools: Read, Glob, Grep, Write, Edit, Bash
 model: opus
+effort: medium
 ---
 Role: You are a senior frontend engineer who translates Figma designs into clean, production-grade HTML/CSS prototypes. You receive Figma render images (the exact visual target), pre-generated CSS, and structured design data. Your job is to build semantic HTML that visually reproduces the Figma design.
 

--- a/agents/issue-writer.md
+++ b/agents/issue-writer.md
@@ -3,6 +3,7 @@ name: issue-writer
 description: Create a single well-formed issue from natural language and update relevant planning docs.
 tools: Read, Glob, Grep, Write, Edit, Bash
 model: sonnet
+effort: medium
 ---
 
 Role: You are a technical issue writer. You create a single well-formed issue from a natural-language description and surgically update the relevant planning docs to maintain consistency.

--- a/agents/migrator.md
+++ b/agents/migrator.md
@@ -3,6 +3,7 @@ name: migrator
 description: Plan and execute migrations — DB schema changes, library upgrades, Python version transitions.
 tools: Read, Glob, Grep, Write, Edit, Bash
 model: opus
+effort: xhigh
 ---
 Role: You are a migration specialist. Your job is to safely upgrade dependencies, schemas, and runtimes with minimal disruption.
 

--- a/agents/mobile-uiux-developer.md
+++ b/agents/mobile-uiux-developer.md
@@ -3,6 +3,7 @@ name: mobile-uiux-developer
 description: Mobile UI/UX development expert who establishes design philosophy based on PRD and UX specs, and generates mobile design systems, wireframes, and React Native (Expo) prototypes.
 tools: Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
 model: opus
+effort: xhigh
 ---
 Role: You are a senior mobile UI/UX developer and design thinker who translates PRDs and UX specs into distinctive, production-grade mobile visual deliverables. Your primary target is React Native (Expo), with extensibility toward SwiftUI and Jetpack Compose.
 

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -3,6 +3,7 @@ name: planner
 description: Break requirements into small, implementable issues with dependencies, ordering, and estimates. Maintain issues.md as SSOT.
 tools: Read, Glob, Grep, Write, Edit
 model: opus
+effort: xhigh
 ---
 Role: You are a technical project planner. You decompose requirements into issues that a developer can pick up and complete in half a day to a day and a half, with no ambiguity about what "done" means.
 

--- a/agents/prd-writer.md
+++ b/agents/prd-writer.md
@@ -3,6 +3,7 @@ name: prd-writer
 description: Interactive PRD writer — guides users through free-form conversation to produce a structured PRD document.
 tools: Read, Glob, Grep, Write, Edit
 model: opus
+effort: high
 ---
 Role: You are a product manager assistant. Your job is to help the user create or update a well-structured PRD.
 

--- a/agents/qa-designer.md
+++ b/agents/qa-designer.md
@@ -3,6 +3,7 @@ name: qa-designer
 description: Design test strategy and test cases from requirements — risk-based prioritization, coverage matrix, not test code.
 tools: Read, Glob, Grep, Write, Edit
 model: opus
+effort: high
 ---
 Role: You are a senior QA architect. You design test strategies that catch real bugs, not strategies that look comprehensive on paper. You prioritize by risk: what breaks the most users the worst?
 

--- a/agents/refactorer.md
+++ b/agents/refactorer.md
@@ -3,6 +3,7 @@ name: refactorer
 description: Improve code structure — extract functions, reduce duplication, apply patterns — without changing behavior.
 tools: Read, Glob, Grep, Write, Edit, Bash
 model: opus
+effort: xhigh
 ---
 Role: You are a refactoring specialist. Your job is to improve code structure and maintainability while preserving existing behavior exactly.
 

--- a/agents/requirement-analyst.md
+++ b/agents/requirement-analyst.md
@@ -3,6 +3,7 @@ name: requirement-analyst
 description: Analyze PRD.md and produce crisp requirements, scope, assumptions, and success metrics.
 tools: Read, Glob, Grep, Write, Edit
 model: sonnet
+effort: medium
 ---
 Role: You are a senior requirements analyst. You translate ambiguous product visions into precise, testable requirements that developers can implement without guessing.
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -3,6 +3,7 @@ name: reviewer
 description: Senior review with integrated security audit — correctness, security, maintainability, complexity; minimal fixes; write review notes.
 tools: Read, Glob, Grep, Edit, Bash, Write
 model: opus
+effort: xhigh
 ---
 Role: You are a senior code reviewer with security expertise. You perform both a code quality review and a security audit in a single pass.
 

--- a/agents/scan-analyst.md
+++ b/agents/scan-analyst.md
@@ -3,6 +3,7 @@ name: scan-analyst
 description: Reverse-engineer requirements from existing code and tests. Tags each requirement as CONFIRMED (test-backed) or INFERRED (code-only).
 tools: Read, Glob, Grep, Write, Edit
 model: sonnet
+effort: low
 ---
 Role: You are a senior requirements analyst performing requirements archaeology. You extract what the system **actually does** from code and tests, producing a requirements document compatible with downstream skills.
 

--- a/agents/scan-architect.md
+++ b/agents/scan-architect.md
@@ -3,6 +3,7 @@ name: scan-architect
 description: Analyze existing codebase architecture from scan context. Documents as-is architecture rather than designing to-be.
 tools: Read, Glob, Grep, Write, Edit
 model: sonnet
+effort: medium
 ---
 Role: You are a pragmatic software architect performing a codebase audit. You document the **as-is** architecture — what the code actually does, not what it should do. You make observations explicit and tag confidence levels.
 

--- a/agents/scan-data-modeler.md
+++ b/agents/scan-data-modeler.md
@@ -3,6 +3,7 @@ name: scan-data-modeler
 description: Extract data models from existing ORM definitions, migration files, and schema declarations. Only invoked when database usage is detected.
 tools: Read, Glob, Grep, Write, Edit
 model: sonnet
+effort: medium
 ---
 Role: You are a senior data engineer performing schema archaeology. You extract the actual data model from code — ORM definitions, migrations, raw SQL, or schema files — and document it in a standardized format.
 

--- a/agents/scan-planner.md
+++ b/agents/scan-planner.md
@@ -3,6 +3,7 @@ name: scan-planner
 description: Generate improvement issues from codebase scan observations — test gaps, tech debt, schema problems, and risk items.
 tools: Read, Glob, Grep, Write, Edit
 model: opus
+effort: medium
 ---
 Role: You are a technical planner who generates improvement issues from codebase scan observations. Unlike the standard planner who decomposes PRD requirements into implementation tasks, you identify actionable improvements from what the scan agents observed in the existing code.
 

--- a/agents/scan-qa-designer.md
+++ b/agents/scan-qa-designer.md
@@ -3,6 +3,7 @@ name: scan-qa-designer
 description: Assess existing test coverage, identify gaps, and produce a test plan based on actual codebase analysis rather than PRD requirements.
 tools: Read, Glob, Grep, Write, Edit
 model: sonnet
+effort: medium
 ---
 Role: You are a senior QA architect performing a test health audit. You assess the current testing state, identify coverage gaps, and design a plan to improve test quality — all grounded in the actual codebase, not a PRD.
 

--- a/agents/team-lead.md
+++ b/agents/team-lead.md
@@ -3,6 +3,7 @@ name: team-lead
 description: Sprint phase executor — receives a specific phase (IMPLEMENT/REVIEW/SHIP) and target issues, executes that phase, updates sprint state.
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
 model: opus
+effort: xhigh
 ---
 Role: You are a tech lead executing a specific sprint phase. The sprint orchestrator (sprint SKILL.md) manages the loop and decides which phase to run next. You receive ONE phase instruction with target issues, execute it, update sprint state, and return.
 

--- a/agents/test-generator.md
+++ b/agents/test-generator.md
@@ -3,6 +3,7 @@ name: test-generator
 description: Scan codebase for test gaps and generate unit/integration/E2E tests that actually pass — no hollow tests, no false coverage.
 tools: Read, Glob, Grep, Write, Edit, Bash
 model: opus
+effort: high
 ---
 Role: You are a senior QA engineer who writes tests that catch real bugs. You prioritize by risk, match existing code style, and never ship hollow tests. Every test you write must have real assertions and must pass on first run.
 

--- a/agents/ui-reviewer.md
+++ b/agents/ui-reviewer.md
@@ -3,6 +3,7 @@ name: ui-reviewer
 description: Audit the design IMPLEMENTATION (rendered state coverage, copy usage, token usage in code, interaction fidelity, accessibility in code, component existence) — implementation-level only. System-level checks belong to design-auditor.
 tools: Read, Glob, Grep, Edit, Bash, Write
 model: sonnet
+effort: high
 ---
 Role: You are a senior UI reviewer specializing in **implementation** conformance to the design system. You evaluate rendered output (HTML/CSS/JSX/RN code) for fidelity to the system's declared contract. You do NOT critique the system itself — that is `design-auditor`'s job.
 

--- a/agents/uiux-developer.md
+++ b/agents/uiux-developer.md
@@ -3,6 +3,7 @@ name: uiux-developer
 description: UI/UX development expert who establishes design philosophy based on PRD and UX specs, and generates design systems, wireframes, and HTML prototypes.
 tools: Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
 model: opus
+effort: xhigh
 ---
 Role: You are a senior UI/UX developer and design thinker who translates PRDs and UX specs into distinctive, production-grade visual deliverables.
 

--- a/agents/ux-designer.md
+++ b/agents/ux-designer.md
@@ -3,6 +3,7 @@ name: ux-designer
 description: Create UX spec (IA, flows, screen states, copy, a11y) from PRD. v0 scope: spec only, no visual design.
 tools: Read, Glob, Grep, Write, Edit
 model: opus
+effort: high
 ---
 Role: You are a senior UX designer who thinks in user flows, not features. You translate requirements into information architecture, screen definitions, and interaction patterns that developers can implement unambiguously.
 

--- a/issues.md
+++ b/issues.md
@@ -20,7 +20,6 @@
 ## Board
 
 ### Backlog
-- [ ] ISSUE-015: Adopt agent effort tiers + refresh model references _(track: platform, P2, 1d)_
 - [ ] ISSUE-016: Worktree/session lifecycle hooks — auto-freeze + run/ cleanup _(track: platform, P2, 1d)_
 - [ ] ISSUE-017: Migrate kit packaging to Claude Code plugin system _(track: platform, P1, 1.5d — spec)_
 
@@ -43,6 +42,7 @@
 - [x] ISSUE-012: Reference Anchor tuning — 2-3 strong cues + 1 literal quote _(track: platform, P2, 0.5d)_
 - [x] ISSUE-013: Consolidate ui-reviewer / design-auditor agents — sharpen role boundaries _(track: platform, P2, 1d)_
 - [x] ISSUE-014: Verify Claude Code feature/version support matrix (spike) _(track: platform, P1, 0.5d)_
+- [x] ISSUE-015: Adopt agent effort tiers + refresh model references _(track: platform, P2, 1d)_
 - [x] ISSUE-018: Over-engineering/simplicity review axis (ponytail benchmark) _(track: platform, P1, 1d)_
 - [x] ISSUE-019: Decision-ladder preamble for implement developer subagent (ponytail benchmark) _(track: platform, P2, 0.5d)_
 - [x] ISSUE-020: Tech-debt marker convention + harvester + review checkpoint (ponytail benchmark) _(track: platform, P2, 1d)_
@@ -944,11 +944,11 @@ Delete `docs/cc_feature_matrix.md`. No runtime impact.
 - PRD-Ref: none (kit self-development; rationale in conversation 2026-06-16)
 - Priority: P2
 - Estimate: 1d
-- Status: backlog
+- Status: done
 - Owner:
-- Branch:
+- Branch: issue/ISSUE-015-effort-tiers
 - GH-Issue:
-- PR:
+- PR: #39
 - Depends-On: ISSUE-014
 
 #### Goal

--- a/project/.claude/settings.snippet.json
+++ b/project/.claude/settings.snippet.json
@@ -4,6 +4,7 @@
     "command": "~/.claude/kit/bin/cc-statusline",
     "padding": 0
   },
+  "fallbackModel": ["sonnet", "haiku"],
   "hooks": {
     "SubagentStart": [
       {

--- a/tests/test_agent_effort.py
+++ b/tests/test_agent_effort.py
@@ -1,0 +1,107 @@
+"""Lint tests for ISSUE-015: agent effort tiers + model reference hygiene.
+
+Enforces the support matrix (docs/cc_feature_matrix.md):
+- every agent declares a valid `effort` for its `model`
+- `xhigh` only on opus (sonnet caps at `high`); `max` is session-only (never frontmatter)
+- the heavy/light split matches the issue scope
+- no retired model id is presented as current in the README
+- the settings snippet parses and its fallbackModel is a list of <=3
+"""
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+AGENTS = sorted((ROOT / "agents").glob("*.md"))
+
+# Valid persisted effort values per model. `max` is session-only (excluded).
+VALID_BY_MODEL = {
+    "opus": {"low", "medium", "high", "xhigh"},
+    "sonnet": {"low", "medium", "high"},
+    "haiku": {"low", "medium", "high"},
+    "fable": {"low", "medium", "high", "xhigh"},
+}
+
+# Agents the issue scope names as heavy (deep reasoning) and light (extraction).
+HEAVY = {"architect", "developer", "reviewer", "diagnostician", "refactorer",
+         "planner", "desktop-uiux-developer", "mobile-uiux-developer", "uiux-developer"}
+LIGHT = {"scan-analyst", "scan-architect", "scan-data-modeler", "scan-qa-designer",
+         "documenter", "issue-writer", "requirement-analyst", "a11y-auditor",
+         "codebase-scanner"}
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    parts = text.split("---")
+    assert len(parts) >= 3, f"{path.name}: no frontmatter block"
+    fm = {}
+    for line in parts[1].splitlines():
+        m = re.match(r"^(\w+):\s*(.*)$", line)
+        if m:
+            fm[m.group(1)] = m.group(2).strip()
+    return fm
+
+
+def test_all_agents_present():
+    assert len(AGENTS) == 33
+
+
+def test_every_agent_has_valid_effort_for_its_model():
+    for a in AGENTS:
+        fm = _frontmatter(a)
+        assert "model" in fm, f"{a.name}: missing model"
+        assert "effort" in fm, f"{a.name}: missing effort"
+        model, effort = fm["model"], fm["effort"]
+        assert model in VALID_BY_MODEL, f"{a.name}: unexpected model {model!r}"
+        assert effort in VALID_BY_MODEL[model], (
+            f"{a.name}: effort {effort!r} invalid for model {model!r} "
+            f"(allowed: {sorted(VALID_BY_MODEL[model])})"
+        )
+
+
+def test_no_xhigh_on_non_opus_capable_models():
+    for a in AGENTS:
+        fm = _frontmatter(a)
+        if fm.get("effort") == "xhigh":
+            assert fm.get("model") in {"opus", "fable"}, (
+                f"{a.name}: xhigh requires opus/fable, got {fm.get('model')!r}"
+            )
+
+
+def test_no_session_only_effort_in_frontmatter():
+    for a in AGENTS:
+        fm = _frontmatter(a)
+        assert fm.get("effort") not in {"max", "ultracode"}, (
+            f"{a.name}: {fm.get('effort')!r} is session-only, not valid in frontmatter"
+        )
+
+
+def test_heavy_agents_run_high_or_above():
+    for a in AGENTS:
+        if a.stem in HEAVY:
+            fm = _frontmatter(a)
+            assert fm["effort"] in {"high", "xhigh"}, (
+                f"{a.stem} is a heavy agent but effort={fm['effort']!r}"
+            )
+
+
+def test_light_agents_run_low_or_medium():
+    for a in AGENTS:
+        if a.stem in LIGHT:
+            fm = _frontmatter(a)
+            assert fm["effort"] in {"low", "medium"}, (
+                f"{a.stem} is an extraction agent but effort={fm['effort']!r}"
+            )
+
+
+def test_readme_has_no_retired_model_id():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert "claude-opus-4-6" not in readme, "retired model id claude-opus-4-6 still in README"
+
+
+def test_settings_snippet_fallback_model_valid():
+    snippet = json.loads((ROOT / "project/.claude/settings.snippet.json").read_text(encoding="utf-8"))
+    fb = snippet.get("fallbackModel")
+    assert isinstance(fb, list) and fb, "fallbackModel must be a non-empty list"
+    assert len(fb) <= 3, "fallbackModel accepts at most 3 entries"


### PR DESCRIPTION
Closes ISSUE-015. Builds on the ISSUE-014 matrix (#38).

## Changes
- **effort tiers** on all 33 agents (`effort:` frontmatter):
  - `xhigh` ×12 — deep-reasoning opus agents (architect, developer, reviewer, diagnostician, refactorer, planner, migrator, data-modeler, desktop/mobile/uiux-developer, team-lead)
  - `high` ×8 — opus generators + sonnet reviewers (sonnet caps at `high`, so no xhigh)
  - `medium` ×10 / `low` ×3 — extraction/scan/doc agents
  - `xhigh` only on opus/fable; `max` (session-only) never in frontmatter; CC auto-fallback keeps it safe on Bedrock/Vertex `opus`→4.6.
- **README**: stale `claude-opus-4-6` statusline example → `claude-opus-4-8`.
- **settings.snippet.json**: `fallbackModel: ["sonnet","haiku"]` (≤3 aliases).
- **tests/test_agent_effort.py**: valid-effort-per-model, no-xhigh-on-sonnet, heavy/light split, README retired-id grep, fallbackModel shape.

## Testing
Full suite **947 passed**. Aliases (`opus`/`sonnet`) kept for forward-compat; no agent prompt/behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)