### PR TITLE
feat(hooks): WorktreeCreate auto-freeze + SessionEnd/Stop cleanup (ISSUE-016)

### DIFF
--- a/issues.md
+++ b/issues.md
@@ -20,7 +20,6 @@
 ## Board
 
 ### Backlog
-- [ ] ISSUE-016: Worktree/session lifecycle hooks — auto-freeze + run/ cleanup _(track: platform, P2, 1d)_
 - [ ] ISSUE-017: Migrate kit packaging to Claude Code plugin system _(track: platform, P1, 1.5d — spec)_
 
 ### Doing
@@ -43,6 +42,7 @@
 - [x] ISSUE-013: Consolidate ui-reviewer / design-auditor agents — sharpen role boundaries _(track: platform, P2, 1d)_
 - [x] ISSUE-014: Verify Claude Code feature/version support matrix (spike) _(track: platform, P1, 0.5d)_
 - [x] ISSUE-015: Adopt agent effort tiers + refresh model references _(track: platform, P2, 1d)_
+- [x] ISSUE-016: Worktree/session lifecycle hooks — auto-freeze + run/ cleanup _(track: platform, P2, 1d)_
 - [x] ISSUE-018: Over-engineering/simplicity review axis (ponytail benchmark) _(track: platform, P1, 1d)_
 - [x] ISSUE-019: Decision-ladder preamble for implement developer subagent (ponytail benchmark) _(track: platform, P2, 0.5d)_
 - [x] ISSUE-020: Tech-debt marker convention + harvester + review checkpoint (ponytail benchmark) _(track: platform, P2, 1d)_
@@ -998,11 +998,11 @@ Revert agent frontmatter and settings snippet changes. Agents fall back to defau
 - PRD-Ref: none (kit self-development; rationale in conversation 2026-06-16)
 - Priority: P2
 - Estimate: 1d
-- Status: backlog
+- Status: done
 - Owner:
-- Branch:
+- Branch: issue/ISSUE-016-lifecycle-hooks
 - GH-Issue:
-- PR:
+- PR: #40
 - Depends-On: ISSUE-014
 
 #### Goal

--- a/project/.claude/hooks/run_cleanup.py
+++ b/project/.claude/hooks/run_cleanup.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""SessionEnd / Stop hook — prune & rotate the kit's per-project runtime state.
+
+`.claude/run/` accumulates state the `agent_state.py` hook writes during a
+session. This cleans it up when the session ends so the directory doesn't grow
+unbounded across sessions. Policy:
+
+- `agent-state.json` — **removed.** It tracks *active* agents for the current
+  session and is meaningless once the session ends.
+- `events.jsonl` — **rotated.** If present and non-empty, it is moved to
+  `events.jsonl.1` (replacing any older `.1`), and the next session starts a
+  fresh log. This bounds disk to the current + one prior session without
+  destroying the most recent trace (telemetry schema work is ISSUE-001).
+
+No-ops cleanly when `.claude/run/` is absent. Never raises (a cleanup hook must
+not disrupt session teardown).
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _project_root(payload: dict) -> Path:
+    # HOOK_ROOT is set by the inline wrapper to handle git worktrees.
+    hook_root = os.environ.get("HOOK_ROOT")
+    if hook_root and (Path(hook_root) / ".claude").is_dir():
+        return Path(hook_root)
+    start = Path(payload.get("cwd") or os.getcwd())
+    cur = start
+    while True:
+        if (cur / ".claude").is_dir():
+            return cur
+        if cur.parent == cur:
+            return start
+        cur = cur.parent
+
+
+def cleanup(run_dir: Path) -> None:
+    if not run_dir.is_dir():
+        return
+    state = run_dir / "agent-state.json"
+    if state.exists():
+        state.unlink()
+    events = run_dir / "events.jsonl"
+    if events.exists() and events.stat().st_size > 0:
+        events.replace(run_dir / "events.jsonl.1")
+    # Drop any leftover temp file from an interrupted atomic write.
+    tmp = run_dir / "agent-state.json.tmp"
+    if tmp.exists():
+        tmp.unlink()
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+    try:
+        cleanup(_project_root(payload) / ".claude" / "run")
+    except OSError:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/project/.claude/hooks/worktree_freeze.py
+++ b/project/.claude/hooks/worktree_freeze.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""WorktreeCreate hook — auto-write the kit's freeze marker for a new worktree.
+
+When Claude Code creates a git worktree, this writes `.claude-kit/freeze-dir.txt`
+(containing the worktree's absolute path) inside it, so `/freeze` / `/guard`
+scope file edits to that worktree without any manual skill step. This is the
+*primary* path on builds that fire `WorktreeCreate`; `scripts/wt_setup.sh` keeps
+an identical write as a fallback for builds that don't (see ISSUE-014 matrix:
+WorktreeCreate is doc-supported but not locally exercised).
+
+Robust by design: the exact payload key for the new worktree path is not pinned,
+so several likely keys are tried before falling back to `cwd`. Any malformed or
+missing payload is a clean no-op (exit 0) — a hook must never break worktree
+creation.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Candidate payload keys for the new worktree's path, most-specific first.
+_PATH_KEYS = ("worktree_path", "worktreePath", "worktree", "new_worktree",
+              "path", "dir", "directory")
+
+
+def _resolve_worktree(payload: dict) -> Path | None:
+    for key in _PATH_KEYS:
+        val = payload.get(key)
+        if isinstance(val, str) and val.strip():
+            return Path(val)
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd.strip():
+        return Path(cwd)
+    return None
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0  # no payload — nothing to do
+    if not isinstance(payload, dict):
+        return 0
+
+    wt = _resolve_worktree(payload)
+    if wt is None:
+        return 0
+    try:
+        marker_dir = wt / ".claude-kit"
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        (marker_dir / "freeze-dir.txt").write_text(f"{wt}\n", encoding="utf-8")
+    except OSError:
+        return 0  # never fail worktree creation over a marker write
+    return 0
+
+
+if __name__ == "__main__":
+    # HOOK_ROOT is set by the inline wrapper for consistency with other hooks,
+    # but this hook resolves its target from the payload, not the repo root.
+    _ = os.environ.get("HOOK_ROOT")
+    raise SystemExit(main())

--- a/project/.claude/settings.snippet.json
+++ b/project/.claude/settings.snippet.json
@@ -6,6 +6,39 @@
   },
   "fallbackModel": ["sonnet", "haiku"],
   "hooks": {
+    "WorktreeCreate": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'R=$(git rev-parse --show-toplevel 2>/dev/null || echo \".\"); G=$(git rev-parse --git-dir 2>/dev/null || echo \".git\"); [ -f \"$G/commondir\" ] && R=$(cd \"$G/$(cat \"$G/commondir\")/..\" && pwd); [ -f \"$R/.claude/hooks/worktree_freeze.py\" ] && HOOK_ROOT=\"$R\" python3 \"$R/.claude/hooks/worktree_freeze.py\" || true'"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'R=$(git rev-parse --show-toplevel 2>/dev/null || echo \".\"); G=$(git rev-parse --git-dir 2>/dev/null || echo \".git\"); [ -f \"$G/commondir\" ] && R=$(cd \"$G/$(cat \"$G/commondir\")/..\" && pwd); [ -f \"$R/.claude/hooks/run_cleanup.py\" ] && HOOK_ROOT=\"$R\" python3 \"$R/.claude/hooks/run_cleanup.py\" || true'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'R=$(git rev-parse --show-toplevel 2>/dev/null || echo \".\"); G=$(git rev-parse --git-dir 2>/dev/null || echo \".git\"); [ -f \"$G/commondir\" ] && R=$(cd \"$G/$(cat \"$G/commondir\")/..\" && pwd); [ -f \"$R/.claude/hooks/run_cleanup.py\" ] && HOOK_ROOT=\"$R\" python3 \"$R/.claude/hooks/run_cleanup.py\" || true'"
+          }
+        ]
+      }
+    ],
     "SubagentStart": [
       {
         "matcher": "*",

--- a/scripts/wt_setup.sh
+++ b/scripts/wt_setup.sh
@@ -21,6 +21,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 WT="$(bash "$SCRIPT_DIR/worktree.sh" create "$BRANCH")"
 
+# Fallback freeze-marker write. On builds that fire the `WorktreeCreate` hook
+# (see project/.claude/hooks/worktree_freeze.py) this is redundant but idempotent;
+# on builds without that event it is the only path that writes the marker. Kept
+# deliberately so worktree freezing never regresses (ISSUE-016).
 mkdir -p "$WT/.claude-kit"
 printf '%s\n' "$WT" > "$WT/.claude-kit/freeze-dir.txt"
 

--- a/tests/test_lifecycle_hooks.py
+++ b/tests/test_lifecycle_hooks.py
@@ -1,0 +1,101 @@
+"""Tests for ISSUE-016 lifecycle hooks: WorktreeCreate freeze + SessionEnd cleanup."""
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HOOKS = Path(__file__).resolve().parents[1] / "project" / ".claude" / "hooks"
+FREEZE = HOOKS / "worktree_freeze.py"
+CLEANUP = HOOKS / "run_cleanup.py"
+
+
+def _run(script: Path, payload, cwd: Path, env_root: Path | None = None) -> int:
+    import os
+    env = dict(os.environ)
+    if env_root is not None:
+        env["HOOK_ROOT"] = str(env_root)
+    proc = subprocess.run(
+        [sys.executable, str(script)],
+        input=(payload if isinstance(payload, str) else json.dumps(payload)).encode("utf-8"),
+        cwd=str(cwd),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return proc.returncode
+
+
+# ── WorktreeCreate freeze hook ───────────────────────────────────────
+
+
+def test_freeze_writes_marker_from_payload_path():
+    with tempfile.TemporaryDirectory() as td:
+        wt = Path(td) / "wt" / "issue-x"
+        wt.mkdir(parents=True)
+        rc = _run(FREEZE, {"hook_event_name": "WorktreeCreate", "worktree_path": str(wt)}, Path(td))
+        assert rc == 0
+        marker = wt / ".claude-kit" / "freeze-dir.txt"
+        assert marker.exists()
+        assert marker.read_text().strip() == str(wt)
+
+
+def test_freeze_falls_back_to_cwd_when_no_path_key():
+    with tempfile.TemporaryDirectory() as td:
+        wt = Path(td)
+        rc = _run(FREEZE, {"hook_event_name": "WorktreeCreate", "cwd": str(wt)}, wt)
+        assert rc == 0
+        assert (wt / ".claude-kit" / "freeze-dir.txt").read_text().strip() == str(wt)
+
+
+def test_freeze_noops_on_empty_payload():
+    with tempfile.TemporaryDirectory() as td:
+        rc = _run(FREEZE, "", Path(td))
+        assert rc == 0  # no crash, no marker
+
+
+def test_freeze_noops_on_malformed_payload():
+    with tempfile.TemporaryDirectory() as td:
+        rc = _run(FREEZE, "not json at all {", Path(td))
+        assert rc == 0
+
+
+# ── SessionEnd / Stop cleanup hook ───────────────────────────────────
+
+
+def test_cleanup_removes_state_and_rotates_events():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        run = root / ".claude" / "run"
+        run.mkdir(parents=True)
+        (run / "agent-state.json").write_text('{"active_agents": {}}', encoding="utf-8")
+        (run / "events.jsonl").write_text('{"e": 1}\n{"e": 2}\n', encoding="utf-8")
+
+        rc = _run(CLEANUP, {"hook_event_name": "SessionEnd", "cwd": str(root)}, root, env_root=root)
+        assert rc == 0
+        assert not (run / "agent-state.json").exists()
+        assert not (run / "events.jsonl").exists()
+        rotated = run / "events.jsonl.1"
+        assert rotated.exists()
+        assert rotated.read_text() == '{"e": 1}\n{"e": 2}\n'
+
+
+def test_cleanup_noops_when_run_dir_absent():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        (root / ".claude").mkdir()  # .claude exists but no run/
+        rc = _run(CLEANUP, {"hook_event_name": "Stop", "cwd": str(root)}, root, env_root=root)
+        assert rc == 0
+
+
+def test_cleanup_empty_events_not_rotated():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        run = root / ".claude" / "run"
+        run.mkdir(parents=True)
+        (run / "events.jsonl").write_text("", encoding="utf-8")
+        rc = _run(CLEANUP, {"hook_event_name": "SessionEnd", "cwd": str(root)}, root, env_root=root)
+        assert rc == 0
+        # empty log: nothing to preserve, no rotation created
+        assert not (run / "events.jsonl.1").exists()


### PR DESCRIPTION
Closes ISSUE-016. Builds on the ISSUE-014 matrix (#38).

## Changes
- **`worktree_freeze.py`** (WorktreeCreate hook) — auto-writes `.claude-kit/freeze-dir.txt` for a new worktree, so `/freeze`/`/guard` scope edits without a manual skill step. Resolves the worktree path robustly (tries several payload keys, falls back to `cwd`) since the exact key isn't locally verified; clean no-op on empty/malformed payload.
- **`run_cleanup.py`** (SessionEnd/Stop hook) — removes `agent-state.json`, rotates `events.jsonl` → `events.jsonl.1` (bounds `.claude/run/` to current + one prior session, preserving the latest trace; telemetry schema is ISSUE-001). No-op when `.claude/run/` absent.
- Both wired into `settings.snippet.json` via the existing commondir-aware inline pattern.
- **`wt_setup.sh`** keeps its freeze-write as a **documented fallback** — on builds without `WorktreeCreate` it's the only writer; on builds with it, redundant but idempotent. No regression either way.
- **`tests/test_lifecycle_hooks.py`** (7): payload-path resolution, cwd fallback, empty/malformed no-op, rotation policy, absent-dir no-op.

## Note (per matrix)
`WorktreeCreate` is doc-supported but **not yet exercised on the local 2.1.185 build** — hence the retained fallback and tolerant payload-key handling. Worth a live probe before removing the imperative path in a follow-up.

## Testing
Lifecycle + merge_settings + freeze_guard + hook_runner + agent_state: **19 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)