### PR TITLE
docs(spec): SPEC-017 — plugin-system migration plan (ISSUE-017)

### DIFF
--- a/docs/specs/SPEC-017.md
+++ b/docs/specs/SPEC-017.md
@@ -1,0 +1,76 @@
+# SPEC-017: Migrate kit packaging to the Claude Code plugin system
+
+> Linked Issue: ISSUE-017
+> Status: `accepted`
+> Date: 2026-06-22
+> Author: claude-dev-kit
+
+## Problem
+
+The kit hand-rolls its own plugin/marketplace layer: `install_project.sh` symlinks `scripts/`, `agents/`, `skills/`, and hooks into a target project; `install_packs.py` + `merge_settings.py` + `packs/*/manifest.yaml` + `validate_pack_manifest.py` implement optional-component selection; per-entry symlinks wire everything together. This bespoke layer is the proximate cause of a recurring bug class — the `scripts/` symlink wiring (#34), `freeze-dir.txt` tracking (#33/#34 era), and the pack-manifest PyYAML hard-fail (ISSUE-021) were all artifacts of maintaining install plumbing that Claude Code now ships natively (`.claude-plugin/plugin.json`, `hooks.json`, `.mcp.json`, `${CLAUDE_PLUGIN_ROOT}`, namespaced skills, `/plugin install`, marketplaces, versioning — all confirmed available, see `docs/cc_feature_matrix.md`). This SPEC decides **how** the kit adopts the native plugin system and decomposes the work into implementation issues. It produces no migration code itself (Spec-Required workflow, per ISSUE-006/007).
+
+## Context
+
+- **Verified platform support** (`docs/cc_feature_matrix.md`, build 2.1.185): full plugin component schema, `${CLAUDE_PLUGIN_ROOT}`/`${CLAUDE_PLUGIN_DATA}`, `/plugin install` with user/project/local scopes, marketplaces, and `version` gating are all present.
+- **Hard constraint — plugin subagents drop `hooks`/`mcpServers`/`permissionMode`** (official, security boundary). The kit's `/freeze`, `/careful`, `/guard` skills embed `hooks:` in frontmatter; under a plugin these are silently ignored unless moved to `hooks.json`.
+- **Mandatory namespacing**: plugin skills become `/<plugin>:<skill>` (e.g. `/kit:implement`). Standalone `.claude/` skills keep short names. Muscle-memory `/implement` would change for every user.
+- **No manifest version floor**: `plugin.json` has no `requiredMinimumVersion`; only Claude Code settings (managed) can hard-gate a version.
+- **Current consumers of the bespoke layer**: `install_project.sh`, `install_packs.py`, `merge_settings.py`, `validate_pack_manifest.py`, `packs/*/manifest.yaml`, and the repo-root `scripts/` symlink resolved by `checkpoint.sh` / `worktree.sh`.
+- The kit is dogfooded on itself and used by at least one real workflow; a flag-day break of `/implement` muscle memory or in-flight worktrees is costly.
+
+## Options
+
+### Option A: Big-bang full migration
+- **Approach**: Convert to a plugin in one PR — author `plugin.json`/`hooks.json`/`.mcp.json`, move all hook-bearing skills to `hooks.json`, switch every `scripts/` reference to `${CLAUDE_PLUGIN_ROOT}`, delete `install_project.sh`/`install_packs.py`/`merge_settings.py`/`validate_pack_manifest.py`, and require `/plugin install`. Skills become `/kit:*` immediately.
+- **Pros**: One transition; no dual-maintenance window; smallest end-state surface.
+- **Cons**: Every user's `/implement` muscle memory breaks on the same day; a single regression blocks the whole kit; no fallback if a feature behaves differently on an older build than the matrix predicts; hard to bisect which sub-change caused a break.
+- **Trade-off**: -4 install scripts in 1 PR, but +6 coupled changes with -100% rollback granularity (revert = revert everything).
+
+### Option B: Phased hybrid with a deprecation window
+- **Approach**: Ship the plugin packaging **alongside** the existing installer. Land the manifests + `hooks.json` migration first (no behavior change for installer users), then `${CLAUDE_PLUGIN_ROOT}` path resolution that works under both layouts, then packs-as-components, then distribution, and finally deprecate `install_project.sh` only after parity is validated. Offer a standalone-install path that preserves short skill names during the window. Decompose into 6 implementation issues, each independently revertable.
+- **Pros**: Each step is ≤1.5d and revertable on its own; users migrate when ready; the matrix's `needs-verify` items (e.g. `WorktreeCreate`) get exercised before the fallback is removed; the bug-class motivation is addressed incrementally with tests at each step.
+- **Cons**: A coexistence window where both the plugin and the installer must work (temporary dual-maintenance, ~2–3 issues' worth of overlap); two code paths to test until the installer is retired.
+- **Trade-off**: +1 deprecation window (~6 issues, ≤1.5d each) and a temporary dual path, in exchange for 6× rollback granularity and removing the same ~4 scripts by the end with each step independently verifiable.
+
+### Option C: Cherry-pick fixes, keep the bespoke installer
+- **Approach**: Don't adopt the plugin system. Borrow only the idea of `${CLAUDE_PLUGIN_ROOT}`-style root resolution to fix the `scripts/` symlink bug, and otherwise keep `install_project.sh` + packs as-is.
+- **Pros**: No namespacing churn; no plugin-subagent hook constraint to handle; least immediate work.
+- **Cons**: Keeps the entire bespoke layer — the bug class persists; the kit never gains `/plugin install`, versioning, or marketplace distribution; diverges further from the platform over time, raising long-run maintenance.
+- **Trade-off**: ~0 new packaging work now, but retains ~4 bespoke scripts indefinitely and forgoes native versioning/distribution (−100% of the platform-alignment benefit that motivates this issue).
+
+## Decision
+
+**Chosen: Option B (phased hybrid with a deprecation window).**
+
+The trade-off line "+1 deprecation window (~6 issues, ≤1.5d each) for 6× rollback granularity, ending at the same ~4-script removal" wins because (i) it directly attacks the bug-class motivation while keeping every step independently testable and revertable, (ii) it lets the matrix's `needs-verify` items (notably `WorktreeCreate`, ISSUE-016) be exercised under the plugin layout before any fallback is deleted, and (iii) it never forces a flag-day break of `/implement` muscle memory — users opt in, and a standalone-install path preserves short names during the window. Option A couples six changes into one un-bisectable PR; Option C abandons the platform-alignment goal that is the entire point of the issue.
+
+## Trade-offs Accepted
+
+- **Dual-maintenance window** (~3 issues of overlap): both the plugin layout and `install_project.sh` must work until ISSUE-027 retires the installer. Mitigated by keeping a single source of truth (`agents/`, `skills/`, `hooks/`) that both packagings read.
+- **Namespacing cost**: under the plugin, skills are `/kit:implement` etc. Users wanting short names must use the standalone-install path. Documented in ISSUE-026; not silently changed.
+- **No manifest version gate**: the kit cannot self-declare "needs CC ≥ 2.1.x" from `plugin.json` — enforced via README prerequisites and (optionally, for orgs) managed settings. A user on too-old a build may see a skill misbehave rather than a clean refusal.
+- **`hooks.json` divergence from frontmatter**: `/freeze`/`/careful`/`/guard` lose their inline `hooks:` under a plugin; the behavior must be reproduced in `hooks.json` and tested, accepting that standalone and plugin installs now express the same hooks in two places until the window closes.
+
+## Migration
+
+Implemented as 6 sequenced, independently-revertable issues (each ≤1.5d). They are **stubs defined here**; they are filed as real issues when the migration is scheduled (this SPEC issue ships the plan, not the code).
+
+1. **ISSUE-022 — Authoring & hooks migration (1.5d)**: add `.claude-plugin/plugin.json`, `hooks/hooks.json`, `.mcp.json`; move `/freeze`,`/careful`,`/guard` hooks from skill frontmatter into `hooks.json`; tests proving the hooks still fire under a plugin layout. No installer change yet.
+2. **ISSUE-023 — Root resolution via `${CLAUDE_PLUGIN_ROOT}` (1d)**: replace the repo-root `scripts/` symlink assumption in `checkpoint.sh`/`worktree.sh`/skill commands with `${CLAUDE_PLUGIN_ROOT}`, falling back to the symlink when the var is unset (works under both layouts). Directly closes the #34 bug class.
+3. **ISSUE-024 — Runtime state to `${CLAUDE_PLUGIN_DATA}` (1d)**: move `.claude-kit/` markers and `.claude/run/` state to `${CLAUDE_PLUGIN_DATA}` when present (survives plugin updates), with the current paths as fallback. Composes with ISSUE-016 hooks.
+4. **ISSUE-025 — Packs as optional components (1.5d)**: model `packs/` as plugin components (or sub-plugins); adapt or retire `install_packs.py`/`merge_settings.py`/`validate_pack_manifest.py`. Each retired script must be tied to the failure mode it caused.
+5. **ISSUE-026 — Distribution & namespacing (1d)**: private git marketplace + `/plugin install kit@…` UX; document the `/kit:` namespace and the standalone-install short-name option in README.
+6. **ISSUE-027 — Deprecate the bespoke installer (1d)**: after parity is validated, remove `install_project.sh` and the now-dead install scripts; flip docs to plugin-first. Gated on ISSUE-022–026 landing.
+
+No data migration is required — `issues.md`, `docs/`, and `templates/` are untouched; only packaging/wiring changes.
+
+## Rollback
+
+This SPEC ships no runtime code, so accepting it has zero runtime impact — the bespoke installer remains authoritative until ISSUE-027. To abandon the migration: mark this SPEC `superseded` (or `drop` ISSUE-017) and do not file ISSUE-022–027; the kit continues on `install_project.sh` unchanged. Each implementation issue carries its own rollback (each is independently revertable by design — the reason Option B was chosen), so a regression in any single step reverts that step without unwinding the others.
+
+## Open Questions
+
+- [ ] Should the kit ship as **one plugin with optional components** or **multiple plugins** (core + sales pack)? — owner: packaging, by: ISSUE-025 kickoff (depends on how `/plugin install` scopes optional components).
+- [ ] Is a standalone-install path (short skill names) worth maintaining long-term, or only through the deprecation window? — owner: process, by: ISSUE-026.
+- [ ] Should the kit publish to a private git marketplace or the skills-directory plugin channel for team distribution? — owner: distribution, by: ISSUE-026.
+- [ ] Can `WorktreeCreate` (ISSUE-016, currently `needs-verify`) be exercised under the plugin layout during ISSUE-023, closing the matrix gap? — owner: platform, by: ISSUE-023.

--- a/issues.md
+++ b/issues.md
@@ -20,7 +20,6 @@
 ## Board
 
 ### Backlog
-- [ ] ISSUE-017: Migrate kit packaging to Claude Code plugin system _(track: platform, P1, 1.5d — spec)_
 
 ### Doing
 
@@ -43,6 +42,7 @@
 - [x] ISSUE-014: Verify Claude Code feature/version support matrix (spike) _(track: platform, P1, 0.5d)_
 - [x] ISSUE-015: Adopt agent effort tiers + refresh model references _(track: platform, P2, 1d)_
 - [x] ISSUE-016: Worktree/session lifecycle hooks — auto-freeze + run/ cleanup _(track: platform, P2, 1d)_
+- [x] ISSUE-017: Migrate kit packaging to Claude Code plugin system (SPEC) _(track: platform, P1, 1.5d — spec)_
 - [x] ISSUE-018: Over-engineering/simplicity review axis (ponytail benchmark) _(track: platform, P1, 1d)_
 - [x] ISSUE-019: Decision-ladder preamble for implement developer subagent (ponytail benchmark) _(track: platform, P2, 0.5d)_
 - [x] ISSUE-020: Tech-debt marker convention + harvester + review checkpoint (ponytail benchmark) _(track: platform, P2, 1d)_
@@ -1051,11 +1051,11 @@ Remove the new hook entries from the settings snippet and restore the freeze-wri
 - PRD-Ref: none (kit self-development; rationale in conversation 2026-06-16)
 - Priority: P1
 - Estimate: 1.5d
-- Status: backlog
+- Status: done
 - Owner:
-- Branch:
+- Branch: issue/ISSUE-017-plugin-spec
 - GH-Issue:
-- PR:
+- PR: #41
 - Depends-On: ISSUE-014
 
 #### Goal


### PR DESCRIPTION
Closes ISSUE-017 (Spec-Required deliverable). Builds on the ISSUE-014 matrix (#38). **No runtime code** — this PR is the reviewed SPEC.

## Decision: Option B — phased hybrid with a deprecation window
Ship plugin packaging **alongside** the existing installer and migrate in 6 independently-revertable steps, retiring `install_project.sh` only after parity — chosen over big-bang (A, un-bisectable) and cherry-pick (C, abandons platform alignment).

## What the SPEC covers (all ACs)
- Layout → `plugin.json` / `hooks.json` / `.mcp.json` mapping.
- `${CLAUDE_PLUGIN_ROOT}` replacing the repo-root `scripts/` symlink — directly closes the #34 bug class; `${CLAUDE_PLUGIN_DATA}` for `.claude-kit/` + `.claude/run/` state.
- **Confirmed constraint**: plugin subagents ignore `hooks`/`mcpServers`/`permissionMode` → `/freeze`,`/careful`,`/guard` must move hooks to `hooks.json`.
- Mandatory `/kit:` namespacing + a standalone short-name install option.
- `packs/` as optional components; fate of `install_packs.py`/`merge_settings.py`/`validate_pack_manifest.py`.
- Distribution (private git marketplace vs skills-dir) + transition/coexistence plan.
- **Decomposed implementation issues ISSUE-022~027**, each ≤1.5d, independently revertable.

## Validation
`scripts/validate_spec.py docs/specs/` → 10/10 pass; `validate_issues.py` → 21/21.

> Note: ISSUE-022~027 are defined as stubs **inside the SPEC** (Migration section); they're filed as real issues when the migration is scheduled — this issue ships the plan, not the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)