### PR TITLE
[ISSUE-046] Fix verify_checkpoint.py's 60s pytest timeout breaking the GREEN gate and hollowing the RED gate on 4-minute suites

### DIFF
--- a/docs/.review/code-review.md
+++ b/docs/.review/code-review.md
@@ -1,0 +1,84 @@
+# Code Review — ISSUE-046 (PR #54, commit 7476313)
+
+Dimension: code (degraded path — runtime /code-review not invocable) + minimality (folded in).
+Reviewer confidence: High. All 137 tests in tests/test_verify_checkpoint.py pass (4:04 wall);
+the 17 new ISSUE-046 tests run fully mocked in 6.3s with no real child processes or sleeps.
+
+## Verdict
+
+**No blocking findings. Approve.** Three Low, non-blocking findings below.
+
+**Scope absorption: ACCEPT.** The two absorbed High findings (verify_ship_smoke timeout=120 at
+scripts/verify_checkpoint.py:1592/1601, verify_implement_test no-runner fallback timeout=60 at
+:954) are one-line conversions through the exact `_test_timeout()` seam this issue creates, were
+done tests-first (TC-046f/g, commit 5962166 precedes 7476313), and are trivially revertible.
+Leaving ship-smoke at 120s would deterministically fail this PR's own SHIP phase — the test file
+alone takes ~244s. This is the minimal correct change set, not scope creep; splitting it out
+would add process overhead to re-touch the same seam.
+
+## Verified (with evidence)
+
+1. **`_run()` contract preserved** — the diff does not touch `_run`; TimeoutExpired → 124
+   sentinel intact at scripts/verify_checkpoint.py:40-45. AC5's `test_timeout_returns_124`
+   (tests/test_verify_checkpoint.py:1096) is unchanged and passes.
+2. **RED-gate ordering correct in all three branches** — the `returncode == 124` check precedes
+   the `== 0` check and the non-zero → PASS fall-through in npm (:628-630), pytest (:640-642),
+   and fallback pytest (:652-654), each printing a "timed out … inconclusive" FAIL.
+3. **`_test_timeout()` (:58-70)** — reads env at call time; probed empirically: `""`, `"  "`,
+   `"abc"`, `"45.5"`, `"-5"`, `"0"`, `"1e6"` → 600; `"  45  "`, `"+45"` → 45; unset → 600.
+   Matches the documented contract exactly; cannot raise (str input, ValueError caught).
+4. **All test-phase call sites converted** — cov run (:753-761) + pytest-cov fallback (:768),
+   RED ×3 (:627/:639/:651), JS worktree (:798), implement-test fallback (:954), ship-smoke
+   pytest (:1592) + npm (:1601). Full `grep timeout=` audit: every remaining hard-coded timeout
+   is non-test-phase (visual diff :338/:1254, computed styles :1298, layout :1342, structural
+   :1387, figma compliance :1436, debt :1467) or explicitly out of scope (deps install
+   :916/:923/:925). verify_gates.py is ISSUE-047 — not flagged.
+5. **Test quality** — mock side-effects are faithful to the real flows: `_red_side_effect`'s
+   `git worktree` porcelain stub satisfies `_find_worktree_path` (:162-180, slug-boundary match
+   on "issue-001-slug"); `_has_real_tests` (:472) and `_detect_test_runners` (:807) operate on
+   real tmp files written by `_make_red_worktree`; `_default_branch` is patched (necessary — the
+   real impl would return "" under the stub); TC-046f/g patch targets (`_run_verify_gates` :854)
+   exist and match the real call sequence. All behavioral asserts; no hollow tests. TC-046a is
+   the first direct coverage of `_run_python_tests_with_coverage` — not duplicate coverage.
+6. **AC coverage** — AC1: suite passes in 244s < 600s (live-run claim consistent); AC2:
+   `test_red_gate_timeout_124_fails_inconclusive`; AC3: `test_red_gate_genuine_failure_exit_1_passes`;
+   AC4: TC-046c/d (mocked, both override and >= 600 default); AC5: passes unchanged.
+
+## Findings
+
+```json
+[
+  {
+    "severity": "Low",
+    "title": "GREEN/ship-smoke timeout failures hide the timeout cause — stderr is dropped",
+    "evidence": "scripts/verify_checkpoint.py:776-778 (also :770-772, :800-802, :955-958, :1593-1596): on exit 124, _run sets stdout=\"\" and puts 'timed out after Ns' in stderr, but these failure paths print only 'FAIL: pytest failed (exit 124)' plus stdout[-500:], which is empty on timeout",
+    "fix": "In the generic non-zero failure paths, also echo a tail of result.stderr, or special-case exit 124 with a one-line hint: '(exit 124 = timed out after {timeout}s; raise KIT_CHECKPOINT_TEST_TIMEOUT)'. In-scope-adjacent but non-blocking given the 600s default makes GREEN timeouts rare"
+  },
+  {
+    "severity": "Low",
+    "title": "KIT_CHECKPOINT_TEST_TIMEOUT is undocumented outside the helper docstring",
+    "evidence": "grep of *.md across the worktree: zero mentions of KIT_CHECKPOINT_TEST_TIMEOUT; precedent exists (KIT_SPRINT_MODE is documented in skills/spec/SKILL.md and skills/implement/SKILL.md); the verify_checkpoint.py module docstring (:1-10) documents exit codes but not this knob",
+    "fix": "Add one line to the verify_checkpoint.py module docstring (and optionally skills/implement/SKILL.md): 'KIT_CHECKPOINT_TEST_TIMEOUT — test-phase subprocess timeout in seconds (default 600)'"
+  },
+  {
+    "severity": "Low",
+    "title": "Triplicated identical 124-check block in verify_implement_red; message does not name the runner",
+    "evidence": "scripts/verify_checkpoint.py:628-630, :640-642, :652-654 — three byte-identical print+return blocks; the npm-branch message is indistinguishable from the pytest-branch message",
+    "fix": "Acceptable as-is: it mirrors the function's pre-existing per-branch early-return structure, and extraction saves ~2 net lines (rejected on minimality grounds). If this function is touched again, extract a shared `_red_timeout_check(result, timeout)` and include cmd[0] in the message"
+  }
+]
+```
+
+## Minimality
+
+Weighed and rejected: extracting the RED 124 triplication (3 call sites, ~2 net lines saved —
+below threshold, and the surrounding ==0/PASS blocks are already per-branch); the redundant
+double-assert `>= 600` + `== _DEFAULT_TEST_TIMEOUT` in TC-046d (3 lines, deliberately encodes
+AC4's ">= 600" plus the exact default — contract pinning, not bloat). `_test_timeout()` has 9
+call sites — not yagni. No dead code, no stdlib reinvention, no speculative config.
+
+```json
+[]
+```
+
+Lean already. Ship.

--- a/docs/.review/findings.json
+++ b/docs/.review/findings.json
@@ -1,0 +1,50 @@
+{
+  "pr_number": "54",
+  "code_source": "reviewer-degraded",
+  "security_source": "reviewer-degraded",
+  "code_findings": [
+    {
+      "severity": "Low",
+      "title": "GREEN/ship-smoke timeout failures hide the timeout cause — stderr is dropped",
+      "evidence": "scripts/verify_checkpoint.py:776-778 (also :770-772, :800-802, :955-958, :1593-1596): on exit 124, _run sets stdout=\"\" and puts 'timed out after Ns' in stderr, but these failure paths print only 'FAIL: pytest failed (exit 124)' plus stdout[-500:], which is empty on timeout",
+      "fix": "In the generic non-zero failure paths, also echo a tail of result.stderr, or special-case exit 124 with a one-line hint: '(exit 124 = timed out after {timeout}s; raise KIT_CHECKPOINT_TEST_TIMEOUT)'. In-scope-adjacent but non-blocking given the 600s default makes GREEN timeouts rare"
+    },
+    {
+      "severity": "Low",
+      "title": "KIT_CHECKPOINT_TEST_TIMEOUT is undocumented outside the helper docstring",
+      "evidence": "grep of *.md across the worktree: zero mentions of KIT_CHECKPOINT_TEST_TIMEOUT; precedent exists (KIT_SPRINT_MODE is documented in skills/spec/SKILL.md and skills/implement/SKILL.md); the verify_checkpoint.py module docstring (:1-10) documents exit codes but not this knob",
+      "fix": "Add one line to the verify_checkpoint.py module docstring (and optionally skills/implement/SKILL.md): 'KIT_CHECKPOINT_TEST_TIMEOUT — test-phase subprocess timeout in seconds (default 600)'"
+    },
+    {
+      "severity": "Low",
+      "title": "Triplicated identical 124-check block in verify_implement_red; message does not name the runner",
+      "evidence": "scripts/verify_checkpoint.py:628-630, :640-642, :652-654 — three byte-identical print+return blocks; the npm-branch message is indistinguishable from the pytest-branch message",
+      "fix": "Acceptable as-is: it mirrors the function's pre-existing per-branch early-return structure, and extraction saves ~2 net lines (rejected on minimality grounds). If this function is touched again, extract a shared `_red_timeout_check(result, timeout)` and include cmd[0] in the message"
+    },
+    {
+      "severity": "Low",
+      "title": "[pre-existing, out of scope — ISSUE-047] verify_gates.py run_gate_unit hard-codes timeout=120 on the full suite; observed during this review's test checkpoint",
+      "evidence": "Observed live in the review test-phase checkpoint output (exit 0, non-blocking here): 'PASS: tests passed' followed by 'GATE FAIL: unit [blocking] (120.1s) / python3: timed out after 120s'. This is scripts/verify_gates.py (separate file, NOT touched by PR #54) — the known pre-existing bug already filed as ISSUE-047 (P0, Depends-On: ISSUE-046). Not a regression from this PR.",
+      "fix": "No action in this PR (scope discipline — issue Scope Out names verify_gates.py explicitly). ISSUE-047 fixes it. Known consequence: ISSUE-046's own SHIP smoke checkpoint is expected to fail on this until ISSUE-047 lands."
+    },
+    {
+      "severity": "Low",
+      "title": "[debt] KIT-DEBT ledger has 3 no-trigger markers (silent-rot risk) — all harvester-self-referential, none from this PR",
+      "evidence": "review debt checkpoint harvest (advisory): scripts/debt_harvest.py:44 (module docstring format example), tests/test_debt_harvest.py:27 and :59 (deliberate no-trigger test fixtures); total 14 markers, 3 no-trigger, 1 malformed — none introduced or touched by PR #54",
+      "fix": "Pre-existing and self-referential (harvester's own docs/tests): consider teaching debt_harvest.py to exclude its own docstring examples and test fixture strings from the ledger so real no-trigger debt stands out"
+    }
+  ],
+  "security_findings": [
+    {
+      "severity": "Low",
+      "title": "No upper bound on KIT_CHECKPOINT_TEST_TIMEOUT: values >= ~1e9 crash the verifier with unhandled OverflowError; large-but-valid values silently remove the hang bound",
+      "evidence": "scripts/verify_checkpoint.py:70 `return value if value > 0 else _DEFAULT_TEST_TIMEOUT` — no upper clamp. Verified: KIT_CHECKPOINT_TEST_TIMEOUT=10**9 -> `OverflowError: timeout is too large` inside subprocess.run (uncaught by _run, which only handles TimeoutExpired/FileNotFoundError at scripts/verify_checkpoint.py:40-52); 10**6 works but effectively disables the timeout. Requires local env control, fails closed (crash = checkpoint failure), no gate bypass — hence Low, not Medium.",
+      "fix": "Clamp in _test_timeout(), e.g. `return min(value, 86400) if value > 0 else _DEFAULT_TEST_TIMEOUT` (optionally print a WARN when clamping). Alternatively catch OverflowError alongside TimeoutExpired in _run, but the clamp is simpler and also restores a meaningful hang bound."
+    }
+  ],
+  "minimality_findings": [],
+  "ui_findings": null,
+  "design_findings": null,
+  "a11y_findings": null,
+  "figma_findings": null
+}

--- a/docs/.review/security-review.md
+++ b/docs/.review/security-review.md
@@ -1,0 +1,35 @@
+# Security Review — PR #54 (ISSUE-046, degraded path)
+
+Scope: `git diff main...HEAD` at 7476313 — scripts/verify_checkpoint.py (+49/-9), tests/test_verify_checkpoint.py (+311). Local/CI developer tooling, not user-facing.
+
+## Verdict
+
+Clean on every high-impact axis. Verified in the actual code, not just the diff description:
+
+- **Injection**: `KIT_CHECKPOINT_TEST_TIMEOUT` flows through `int()` (scripts/verify_checkpoint.py:65-70) and only into the `timeout=` kwarg of `subprocess.run` (scripts/verify_checkpoint.py:38-39). It never reaches argv or a shell string. All call sites use static list-form argv; `grep shell=True` over the file returns nothing. No new subprocess call sites introduced.
+- **Input validation**: probed empirically — empty, `"abc"`, `"-5"`, `"0"`, `"inf"`, `"4.5"`, unicode digits (`"٦٠٠"` → 600, harmless int), whitespace, underscores, and 5000-digit strings (Python 3.11 int-str limit raises ValueError → caught) all resolve safely to the default or a plain int. `timeout=0` ("disable" path in `_run`) is unreachable via the env var since non-positive maps to the default. One robustness gap remains (finding below).
+- **Fail direction**: the one crash path found is fail-closed — an unhandled exception in the verifier fails the checkpoint; no gate-bypass path exists. The new returncode==124 branch also fails closed (`return False`).
+- **Secrets / dependencies / deserialization / network / XSS / misconfig**: nothing added or touched by this diff.
+- **DoS from raised defaults (60/120s → 600s)**: deliberate, documented tradeoff (suite runs ~4.5 min); a hung suite now occupies a runner up to 10 min, bounded in practice by CI job-level timeouts. Not a finding.
+
+One Low-severity robustness finding; nothing blocking.
+
+## Findings
+
+```json
+[
+  {
+    "severity": "Low",
+    "title": "No upper bound on KIT_CHECKPOINT_TEST_TIMEOUT: values >= ~1e9 crash the verifier with unhandled OverflowError; large-but-valid values silently remove the hang bound",
+    "evidence": "scripts/verify_checkpoint.py:70 `return value if value > 0 else _DEFAULT_TEST_TIMEOUT` — no upper clamp. Verified: KIT_CHECKPOINT_TEST_TIMEOUT=10**9 -> `OverflowError: timeout is too large` inside subprocess.run (uncaught by _run, which only handles TimeoutExpired/FileNotFoundError at scripts/verify_checkpoint.py:40-52); 10**6 works but effectively disables the timeout. Requires local env control, fails closed (crash = checkpoint failure), no gate bypass — hence Low, not Medium.",
+    "fix": "Clamp in _test_timeout(), e.g. `return min(value, 86400) if value > 0 else _DEFAULT_TEST_TIMEOUT` (optionally print a WARN when clamping). Alternatively catch OverflowError alongside TimeoutExpired in _run, but the clamp is simpler and also restores a meaningful hang bound."
+  }
+]
+```
+
+## Self-review
+
+- Severity re-checked: the crash needs env control on the developer's own machine/runner (anyone with that can already run arbitrary code) and fails closed — Low is impact-honest.
+- False-positive check: both the OverflowError (10**9 and 10**18 variants) and the fail-back cases were reproduced by executing `_test_timeout()`/`_run()` directly, not inferred.
+- Blind-spot re-scan: re-read the diff for shell usage, string-built commands, secrets, deserialization of the env value, and log injection via the f-string 124 messages (value is an int by print time) — nothing found.
+- Confidence: High — small diff, every claim executed against the worktree code.

--- a/docs/review_notes/ISSUE-046.md
+++ b/docs/review_notes/ISSUE-046.md
@@ -1,0 +1,35 @@
+# Review Notes — PR #54
+
+## Code Review
+_Source: reviewer-degraded_
+
+- **[Low] GREEN/ship-smoke timeout failures hide the timeout cause — stderr is dropped**
+  Evidence: scripts/verify_checkpoint.py:776-778 (also :770-772, :800-802, :955-958, :1593-1596): on exit 124, _run sets stdout="" and puts 'timed out after Ns' in stderr, but these failure paths print only 'FAIL: pytest failed (exit 124)' plus stdout[-500:], which is empty on timeout
+  Fix: In the generic non-zero failure paths, also echo a tail of result.stderr, or special-case exit 124 with a one-line hint: '(exit 124 = timed out after {timeout}s; raise KIT_CHECKPOINT_TEST_TIMEOUT)'. In-scope-adjacent but non-blocking given the 600s default makes GREEN timeouts rare
+
+- **[Low] KIT_CHECKPOINT_TEST_TIMEOUT is undocumented outside the helper docstring**
+  Evidence: grep of *.md across the worktree: zero mentions of KIT_CHECKPOINT_TEST_TIMEOUT; precedent exists (KIT_SPRINT_MODE is documented in skills/spec/SKILL.md and skills/implement/SKILL.md); the verify_checkpoint.py module docstring (:1-10) documents exit codes but not this knob
+  Fix: Add one line to the verify_checkpoint.py module docstring (and optionally skills/implement/SKILL.md): 'KIT_CHECKPOINT_TEST_TIMEOUT — test-phase subprocess timeout in seconds (default 600)'
+
+- **[Low] Triplicated identical 124-check block in verify_implement_red; message does not name the runner**
+  Evidence: scripts/verify_checkpoint.py:628-630, :640-642, :652-654 — three byte-identical print+return blocks; the npm-branch message is indistinguishable from the pytest-branch message
+  Fix: Acceptable as-is: it mirrors the function's pre-existing per-branch early-return structure, and extraction saves ~2 net lines (rejected on minimality grounds). If this function is touched again, extract a shared `_red_timeout_check(result, timeout)` and include cmd[0] in the message
+
+- **[Low] [pre-existing, out of scope — ISSUE-047] verify_gates.py run_gate_unit hard-codes timeout=120 on the full suite; observed during this review's test checkpoint**
+  Evidence: Observed live in the review test-phase checkpoint output (exit 0, non-blocking here): 'PASS: tests passed' followed by 'GATE FAIL: unit [blocking] (120.1s) / python3: timed out after 120s'. This is scripts/verify_gates.py (separate file, NOT touched by PR #54) — the known pre-existing bug already filed as ISSUE-047 (P0, Depends-On: ISSUE-046). Not a regression from this PR.
+  Fix: No action in this PR (scope discipline — issue Scope Out names verify_gates.py explicitly). ISSUE-047 fixes it. Known consequence: ISSUE-046's own SHIP smoke checkpoint is expected to fail on this until ISSUE-047 lands.
+
+- **[Low] [debt] KIT-DEBT ledger has 3 no-trigger markers (silent-rot risk) — all harvester-self-referential, none from this PR**
+  Evidence: review debt checkpoint harvest (advisory): scripts/debt_harvest.py:44 (module docstring format example), tests/test_debt_harvest.py:27 and :59 (deliberate no-trigger test fixtures); total 14 markers, 3 no-trigger, 1 malformed — none introduced or touched by PR #54
+  Fix: Pre-existing and self-referential (harvester's own docs/tests): consider teaching debt_harvest.py to exclude its own docstring examples and test fixture strings from the ledger so real no-trigger debt stands out
+
+## Security Findings
+_Source: reviewer-degraded_
+
+- **[Low] No upper bound on KIT_CHECKPOINT_TEST_TIMEOUT: values >= ~1e9 crash the verifier with unhandled OverflowError; large-but-valid values silently remove the hang bound**
+  Evidence: scripts/verify_checkpoint.py:70 `return value if value > 0 else _DEFAULT_TEST_TIMEOUT` — no upper clamp. Verified: KIT_CHECKPOINT_TEST_TIMEOUT=10**9 -> `OverflowError: timeout is too large` inside subprocess.run (uncaught by _run, which only handles TimeoutExpired/FileNotFoundError at scripts/verify_checkpoint.py:40-52); 10**6 works but effectively disables the timeout. Requires local env control, fails closed (crash = checkpoint failure), no gate bypass — hence Low, not Medium.
+  Fix: Clamp in _test_timeout(), e.g. `return min(value, 86400) if value > 0 else _DEFAULT_TEST_TIMEOUT` (optionally print a WARN when clamping). Alternatively catch OverflowError alongside TimeoutExpired in _run, but the clamp is simpler and also restores a meaningful hang bound.
+
+## Over-Engineering
+
+_No findings._

--- a/scripts/verify_checkpoint.py
+++ b/scripts/verify_checkpoint.py
@@ -52,6 +52,24 @@ def _run(cmd: list[str], timeout: int = 30, **kwargs) -> subprocess.CompletedPro
         return mock
 
 
+_DEFAULT_TEST_TIMEOUT = 600  # seconds — default for test-phase subprocess runs
+
+
+def _test_timeout() -> int:
+    """Resolve the test-phase timeout at call time.
+
+    Reads KIT_CHECKPOINT_TEST_TIMEOUT (seconds). A valid positive integer
+    overrides the default; unset, non-numeric, or non-positive values fall
+    back to _DEFAULT_TEST_TIMEOUT.
+    """
+    raw = os.environ.get("KIT_CHECKPOINT_TEST_TIMEOUT", "")
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_TEST_TIMEOUT
+    return value if value > 0 else _DEFAULT_TEST_TIMEOUT
+
+
 def _run_with_retry(cmd: list[str], max_retries: int = 2, delay: float = 1.0, **kwargs) -> subprocess.CompletedProcess:
     """Run a command with retry logic for transient network failures.
 
@@ -602,9 +620,14 @@ def verify_implement_red(issue_id: str, **_) -> bool:
     # pass even when the real JS suite would have passed).
     has_python, has_js = _detect_test_runners(wt)
 
+    timeout = _test_timeout()
+
     # JS first: an explicit scripts.test is the strongest signal.
     if has_js:
-        result = _run(["npm", "test", "--", "--passWithNoTests"], cwd=wt_path, timeout=60)
+        result = _run(["npm", "test", "--", "--passWithNoTests"], cwd=wt_path, timeout=timeout)
+        if result.returncode == 124:
+            print(f"FAIL: RED phase — test run timed out after {timeout}s (exit 124) — inconclusive, cannot verify genuine RED")
+            return False
         if result.returncode == 0:
             print("FAIL: RED phase — tests passed but should fail before implementation.")
             print("  TDD requires: write failing tests first, then implement to make them pass.")
@@ -613,7 +636,10 @@ def verify_implement_red(issue_id: str, **_) -> bool:
         return True
 
     if has_python:
-        result = _run(["python3", "-m", "pytest", "-q", "--tb=short"], cwd=wt_path, timeout=60)
+        result = _run(["python3", "-m", "pytest", "-q", "--tb=short"], cwd=wt_path, timeout=timeout)
+        if result.returncode == 124:
+            print(f"FAIL: RED phase — test run timed out after {timeout}s (exit 124) — inconclusive, cannot verify genuine RED")
+            return False
         if result.returncode == 0:
             print("FAIL: RED phase — tests passed but should fail before implementation.")
             print("  TDD requires: write failing tests first, then implement to make them pass.")
@@ -622,7 +648,10 @@ def verify_implement_red(issue_id: str, **_) -> bool:
         return True
 
     # Fallback: try pytest
-    result = _run(["python3", "-m", "pytest", "-q", "--tb=short"], cwd=wt_path, timeout=60)
+    result = _run(["python3", "-m", "pytest", "-q", "--tb=short"], cwd=wt_path, timeout=timeout)
+    if result.returncode == 124:
+        print(f"FAIL: RED phase — test run timed out after {timeout}s (exit 124) — inconclusive, cannot verify genuine RED")
+        return False
     if result.returncode == 0:
         print("FAIL: RED phase — tests passed but should fail before implementation.")
         return False
@@ -720,6 +749,7 @@ _MIN_COVERAGE = 60  # Minimum line coverage percentage
 
 def _run_python_tests_with_coverage(cwd: str | None) -> bool:
     """Run pytest with coverage and enforce minimum threshold."""
+    timeout = _test_timeout()
     result = _run(
         [
             "python3", "-m", "pytest", "-q", "--tb=short",
@@ -727,7 +757,7 @@ def _run_python_tests_with_coverage(cwd: str | None) -> bool:
             f"--cov-fail-under={_MIN_COVERAGE}",
         ],
         cwd=cwd,
-        timeout=60,
+        timeout=timeout,
     )
 
     if result.returncode != 0:
@@ -735,7 +765,7 @@ def _run_python_tests_with_coverage(cwd: str | None) -> bool:
         # pytest-cov not installed — fall back to plain pytest
         if "no module named" in stderr_lower or "unrecognized arguments: --cov" in stderr_lower:
             print(f"WARN: pytest-cov not available, running without coverage enforcement")
-            result = _run(["python3", "-m", "pytest", "-q", "--tb=short"], cwd=cwd, timeout=60)
+            result = _run(["python3", "-m", "pytest", "-q", "--tb=short"], cwd=cwd, timeout=timeout)
             if result.returncode != 0:
                 print(f"FAIL: pytest failed (exit {result.returncode})")
                 if result.stdout:
@@ -765,7 +795,7 @@ def _run_js_tests_in_worktree(cwd: str | None) -> bool:
     except (OSError, json.JSONDecodeError):
         return True
 
-    result = _run(["npm", "test", "--", "--passWithNoTests"], cwd=cwd, timeout=60)
+    result = _run(["npm", "test", "--", "--passWithNoTests"], cwd=cwd, timeout=_test_timeout())
     if result.returncode != 0:
         print(f"FAIL: npm test failed (exit {result.returncode})")
         if result.stdout:
@@ -921,7 +951,7 @@ def verify_implement_test(issue_id: str, **_) -> bool:
 
     if not has_python and not has_js:
         # Fallback: try pytest anyway
-        result = _run(["python3", "-m", "pytest", "-q", "--tb=short"], cwd=cwd, timeout=60)
+        result = _run(["python3", "-m", "pytest", "-q", "--tb=short"], cwd=cwd, timeout=_test_timeout())
         if result.returncode != 0:
             print(f"FAIL: pytest failed (exit {result.returncode})")
             if result.stdout:
@@ -1556,9 +1586,10 @@ def verify_ship_smoke(issue_id: str, **_) -> bool:
     has_js = (root / "package.json").exists()
 
     ok = True
+    timeout = _test_timeout()
 
     if has_python:
-        result = _run(["python3", "-m", "pytest", "-q", "--tb=short"], cwd=str(root), timeout=120)
+        result = _run(["python3", "-m", "pytest", "-q", "--tb=short"], cwd=str(root), timeout=timeout)
         if result.returncode != 0:
             print("FAIL: post-merge smoke test failed on main")
             if result.stdout:
@@ -1567,7 +1598,7 @@ def verify_ship_smoke(issue_id: str, **_) -> bool:
             ok = False
 
     if has_js:
-        result = _run(["npm", "test", "--", "--passWithNoTests"], cwd=str(root), timeout=120)
+        result = _run(["npm", "test", "--", "--passWithNoTests"], cwd=str(root), timeout=timeout)
         if result.returncode != 0:
             print("FAIL: npm test failed on main")
             if result.stdout:

--- a/tests/test_verify_checkpoint.py
+++ b/tests/test_verify_checkpoint.py
@@ -1546,6 +1546,7 @@ class TestKitCheckpointTestTimeoutInvalidEnv:
         with patch.object(vc, "_run", side_effect=side_effect):
             # Must not raise despite the garbage env value
             assert vc._run_python_tests_with_coverage("/tmp/wt") is True
+        assert timeouts[0] == _DEFAULT_TEST_TIMEOUT
 
 
 class TestKitCheckpointTestTimeoutImplementTestFallback:
@@ -1615,4 +1616,3 @@ class TestKitCheckpointTestTimeoutShipSmoke:
         timeouts = self._run_smoke(tmp_path, monkeypatch)
         assert timeouts["pytest"] == 45
         assert timeouts["npm"] == 45
-        assert timeouts[0] == _DEFAULT_TEST_TIMEOUT

--- a/tests/test_verify_checkpoint.py
+++ b/tests/test_verify_checkpoint.py
@@ -1546,4 +1546,73 @@ class TestKitCheckpointTestTimeoutInvalidEnv:
         with patch.object(vc, "_run", side_effect=side_effect):
             # Must not raise despite the garbage env value
             assert vc._run_python_tests_with_coverage("/tmp/wt") is True
+
+
+class TestKitCheckpointTestTimeoutImplementTestFallback:
+    """TC-046f — verify_implement_test's no-runner fallback pytest run must
+    use the configurable test-phase timeout (same seam, scope addition)."""
+
+    def _run_fallback(self, tmp_path):
+        timeouts: list = []
+
+        def side_effect(cmd, **kwargs):
+            if "pytest" in cmd:
+                timeouts.append(kwargs.get("timeout"))
+            return _mock_run(0)
+
+        with patch.object(vc, "_run", side_effect=side_effect), \
+             patch.object(vc, "_find_worktree_path", return_value=str(tmp_path)), \
+             patch.object(vc, "_ensure_deps_installed", return_value=True), \
+             patch.object(vc, "_detect_test_runners", return_value=(False, False)), \
+             patch.object(vc, "_test_plan_has_high_risk", return_value=False), \
+             patch.object(vc, "_run_verify_gates", return_value=True):
+            assert vc.verify_implement_test("ISSUE-001") is True
+        return timeouts
+
+    def test_implement_test_fallback_timeout_default_600(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(_TIMEOUT_ENV, raising=False)
+        assert self._run_fallback(tmp_path) == [_DEFAULT_TEST_TIMEOUT]
+
+    def test_implement_test_fallback_timeout_env_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(_TIMEOUT_ENV, "45")
+        assert self._run_fallback(tmp_path) == [45]
+
+
+class TestKitCheckpointTestTimeoutShipSmoke:
+    """TC-046g — verify_ship_smoke's full-suite pytest and npm runs must use
+    the configurable test-phase timeout (scope addition). No special 124
+    handling there — a timeout simply remains a smoke-gate failure."""
+
+    def _run_smoke(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(vc, "_repo_root", lambda: tmp_path)
+        monkeypatch.setattr(vc, "_default_branch", lambda: "main")
+        (tmp_path / "pyproject.toml").write_text("[tool.pytest]\n")
+        (tmp_path / "package.json").write_text('{"scripts": {"test": "vitest run"}}')
+        timeouts: dict = {}
+
+        def side_effect(cmd, **kwargs):
+            if cmd == ["git", "branch", "--show-current"]:
+                return _mock_run(0, stdout="main\n")
+            if "pytest" in cmd:
+                timeouts["pytest"] = kwargs.get("timeout")
+            if cmd[:2] == ["npm", "test"]:
+                timeouts["npm"] = kwargs.get("timeout")
+            return _mock_run(0)
+
+        with patch.object(vc, "_run", side_effect=side_effect), \
+             patch.object(vc, "_run_verify_gates", return_value=True):
+            assert vc.verify_ship_smoke("ISSUE-001") is True
+        return timeouts
+
+    def test_ship_smoke_timeouts_default_600(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(_TIMEOUT_ENV, raising=False)
+        timeouts = self._run_smoke(tmp_path, monkeypatch)
+        assert timeouts["pytest"] == _DEFAULT_TEST_TIMEOUT
+        assert timeouts["npm"] == _DEFAULT_TEST_TIMEOUT
+
+    def test_ship_smoke_timeouts_env_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(_TIMEOUT_ENV, "45")
+        timeouts = self._run_smoke(tmp_path, monkeypatch)
+        assert timeouts["pytest"] == 45
+        assert timeouts["npm"] == 45
         assert timeouts[0] == _DEFAULT_TEST_TIMEOUT

--- a/tests/test_verify_checkpoint.py
+++ b/tests/test_verify_checkpoint.py
@@ -1305,3 +1305,245 @@ class TestVerifyGatesIntegration:
              patch.object(vg, "run_applicable_gates", return_value=[]):
             result = vc.verify_implement_test("ISSUE-001")
             assert result is True
+
+
+# ── ISSUE-046: test-phase timeout config & RED exit-124 handling ─────
+#
+# The test-run call sites (_run_python_tests_with_coverage cov + fallback,
+# verify_implement_red pytest/npm, _run_js_tests_in_worktree npm) must use a
+# configurable timeout: env var KIT_CHECKPOINT_TEST_TIMEOUT (seconds), read
+# at CALL time, defaulting to 600. verify_implement_red must treat _run's
+# exit-124 timeout sentinel as inconclusive (FAIL), not as a RED pass.
+
+_TIMEOUT_ENV = "KIT_CHECKPOINT_TEST_TIMEOUT"
+_DEFAULT_TEST_TIMEOUT = 600  # new default for test-phase subprocess runs
+
+
+def _make_red_worktree(tmp_path: Path) -> Path:
+    """Create a worktree dir that satisfies verify_implement_red's pre-checks.
+
+    Python project (pyproject.toml, no package.json) so the pytest branch is
+    reached, plus one real (non-hollow) test file.
+    """
+    wt_path = tmp_path / "wt" / "issue" / "issue-001-slug"
+    wt_path.mkdir(parents=True)
+    (wt_path / "pyproject.toml").write_text("[tool.pytest]\n")
+    tests_dir = wt_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_feature.py").write_text(
+        "def test_new_feature():\n    assert False  # not implemented yet\n"
+    )
+    return wt_path
+
+
+def _red_side_effect(wt_path: Path, pytest_result, timeouts: list):
+    """Build a _run side effect for verify_implement_red that records the
+    timeout kwarg of the pytest invocation and returns pytest_result for it."""
+
+    def side_effect(cmd, **kwargs):
+        if cmd[:2] == ["git", "worktree"]:
+            return _mock_run(0, stdout=f"worktree {wt_path}\n")
+        if cmd[:2] == ["git", "diff"] and "main" in cmd:
+            return _mock_run(0, stdout="tests/test_feature.py\n")
+        if "pytest" in cmd:
+            timeouts.append(kwargs.get("timeout"))
+            return pytest_result
+        return _mock_run(0, stdout="")
+
+    return side_effect
+
+
+class TestGreenGateResult:
+    """TC-046a — GREEN verifier pass/fail contract (mocked _run, no children)."""
+
+    def test_green_gate_passes_on_exit_zero(self):
+        """Cov run exits 0 → GREEN gate returns True."""
+        calls = []
+
+        def side_effect(cmd, **kwargs):
+            calls.append(cmd)
+            return _mock_run(0)
+
+        with patch.object(vc, "_run", side_effect=side_effect):
+            assert vc._run_python_tests_with_coverage("/tmp/wt") is True
+        assert len(calls) == 1  # no fallback triggered on success
+
+    def test_green_gate_fails_on_genuine_failure(self):
+        """Exit 1 with stderr NOT matching the pytest-cov-missing pattern →
+        genuine failure → returns False (and no fallback rerun)."""
+        calls = []
+
+        def side_effect(cmd, **kwargs):
+            calls.append(cmd)
+            return _mock_run(1, stdout="FAILED tests/test_x.py", stderr="assertion error")
+
+        with patch.object(vc, "_run", side_effect=side_effect):
+            assert vc._run_python_tests_with_coverage("/tmp/wt") is False
+        assert len(calls) == 1  # stderr didn't match fallback pattern → no rerun
+
+
+class TestRedGateExitCodeMatrix:
+    """TC-046b — RED gate must distinguish timeout (124) from genuine failure."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_default_branch(self, monkeypatch):
+        monkeypatch.setattr(vc, "_default_branch", lambda: "main")
+
+    def test_red_gate_timeout_124_fails_inconclusive(self, tmp_path, capsys):
+        """Exit 124 (timeout sentinel) is NOT evidence tests fail — RED must
+        FAIL and report the run as timed out / inconclusive."""
+        wt_path = _make_red_worktree(tmp_path)
+        timeouts: list = []
+        side_effect = _red_side_effect(
+            wt_path, _mock_run(124, stderr="python3: timed out after 60s"), timeouts
+        )
+
+        with patch.object(vc, "_run", side_effect=side_effect):
+            result = vc.verify_implement_red("ISSUE-001")
+
+        assert result is False
+        out_lower = capsys.readouterr().out.lower()
+        assert "inconclusive" in out_lower
+        assert "timed out" in out_lower or "timeout" in out_lower
+
+    def test_red_gate_genuine_failure_exit_1_passes(self, tmp_path):
+        """Exit 1 (real test failures) → RED PASS (inverted-logic contract)."""
+        wt_path = _make_red_worktree(tmp_path)
+        timeouts: list = []
+        side_effect = _red_side_effect(wt_path, _mock_run(1, stdout="FAILED"), timeouts)
+
+        with patch.object(vc, "_run", side_effect=side_effect):
+            assert vc.verify_implement_red("ISSUE-001") is True
+
+    def test_red_gate_exit_zero_fails(self, tmp_path):
+        """Exit 0 (tests already pass) → RED FAIL (inverted-logic contract)."""
+        wt_path = _make_red_worktree(tmp_path)
+        timeouts: list = []
+        side_effect = _red_side_effect(wt_path, _mock_run(0), timeouts)
+
+        with patch.object(vc, "_run", side_effect=side_effect):
+            assert vc.verify_implement_red("ISSUE-001") is False
+
+
+class TestKitCheckpointTestTimeoutEnvOverride:
+    """TC-046c — KIT_CHECKPOINT_TEST_TIMEOUT env var overrides the test-run
+    timeout at every fixed call site (read at CALL time)."""
+
+    def test_kit_checkpoint_test_timeout_env_override_cov_run(self, monkeypatch):
+        monkeypatch.setenv(_TIMEOUT_ENV, "45")
+        timeouts: list = []
+
+        def side_effect(cmd, **kwargs):
+            timeouts.append(kwargs.get("timeout"))
+            return _mock_run(0)
+
+        with patch.object(vc, "_run", side_effect=side_effect):
+            assert vc._run_python_tests_with_coverage("/tmp/wt") is True
+        assert timeouts == [45]
+
+    def test_kit_checkpoint_test_timeout_env_override_fallback_run(self, monkeypatch):
+        monkeypatch.setenv(_TIMEOUT_ENV, "45")
+        timeouts: list = []
+
+        def side_effect(cmd, **kwargs):
+            timeouts.append(kwargs.get("timeout"))
+            if len(timeouts) == 1:
+                # cov run fails with the pytest-cov-missing pattern → fallback
+                return _mock_run(1, stderr="unrecognized arguments: --cov")
+            return _mock_run(0)
+
+        with patch.object(vc, "_run", side_effect=side_effect):
+            assert vc._run_python_tests_with_coverage("/tmp/wt") is True
+        assert len(timeouts) == 2  # cov run + plain fallback run
+        assert timeouts[0] == 45
+        assert timeouts[1] == 45
+
+    def test_kit_checkpoint_test_timeout_env_override_red_python_run(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv(_TIMEOUT_ENV, "45")
+        monkeypatch.setattr(vc, "_default_branch", lambda: "main")
+        wt_path = _make_red_worktree(tmp_path)
+        timeouts: list = []
+        side_effect = _red_side_effect(wt_path, _mock_run(1, stdout="FAILED"), timeouts)
+
+        with patch.object(vc, "_run", side_effect=side_effect):
+            vc.verify_implement_red("ISSUE-001")
+        assert timeouts == [45]
+
+    def test_kit_checkpoint_test_timeout_env_override_npm_run(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv(_TIMEOUT_ENV, "45")
+        (tmp_path / "package.json").write_text('{"scripts": {"test": "vitest run"}}')
+        timeouts: list = []
+
+        def side_effect(cmd, **kwargs):
+            if cmd[:2] == ["npm", "test"]:
+                timeouts.append(kwargs.get("timeout"))
+            return _mock_run(0)
+
+        with patch.object(vc, "_run", side_effect=side_effect):
+            assert vc._run_js_tests_in_worktree(str(tmp_path)) is True
+        assert timeouts == [45]
+
+
+class TestKitCheckpointTestTimeoutDefault:
+    """TC-046d — env unset → default timeout is 600s (suite takes ~4.5 min)."""
+
+    def test_green_gate_timeout_default_600(self, monkeypatch):
+        monkeypatch.delenv(_TIMEOUT_ENV, raising=False)
+        timeouts: list = []
+
+        def side_effect(cmd, **kwargs):
+            timeouts.append(kwargs.get("timeout"))
+            return _mock_run(0)
+
+        with patch.object(vc, "_run", side_effect=side_effect):
+            assert vc._run_python_tests_with_coverage("/tmp/wt") is True
+        assert timeouts[0] >= 600
+        assert timeouts[0] == _DEFAULT_TEST_TIMEOUT
+
+    def test_red_gate_timeout_default_600(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(_TIMEOUT_ENV, raising=False)
+        monkeypatch.setattr(vc, "_default_branch", lambda: "main")
+        wt_path = _make_red_worktree(tmp_path)
+        timeouts: list = []
+        side_effect = _red_side_effect(wt_path, _mock_run(1, stdout="FAILED"), timeouts)
+
+        with patch.object(vc, "_run", side_effect=side_effect):
+            vc.verify_implement_red("ISSUE-001")
+        assert timeouts[0] >= 600
+        assert timeouts[0] == _DEFAULT_TEST_TIMEOUT
+
+    def test_js_gate_timeout_default_600(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(_TIMEOUT_ENV, raising=False)
+        (tmp_path / "package.json").write_text('{"scripts": {"test": "vitest run"}}')
+        timeouts: list = []
+
+        def side_effect(cmd, **kwargs):
+            if cmd[:2] == ["npm", "test"]:
+                timeouts.append(kwargs.get("timeout"))
+            return _mock_run(0)
+
+        with patch.object(vc, "_run", side_effect=side_effect):
+            assert vc._run_js_tests_in_worktree(str(tmp_path)) is True
+        assert timeouts[0] >= 600
+        assert timeouts[0] == _DEFAULT_TEST_TIMEOUT
+
+
+class TestKitCheckpointTestTimeoutInvalidEnv:
+    """TC-046e — non-numeric env value falls back to the default, no crash."""
+
+    def test_invalid_env_falls_back_to_default_without_raising(self, monkeypatch):
+        monkeypatch.setenv(_TIMEOUT_ENV, "abc")
+        timeouts: list = []
+
+        def side_effect(cmd, **kwargs):
+            timeouts.append(kwargs.get("timeout"))
+            return _mock_run(0)
+
+        with patch.object(vc, "_run", side_effect=side_effect):
+            # Must not raise despite the garbage env value
+            assert vc._run_python_tests_with_coverage("/tmp/wt") is True
+        assert timeouts[0] == _DEFAULT_TEST_TIMEOUT


### PR DESCRIPTION
Closes #53

## Summary

`scripts/verify_checkpoint.py` hard-coded `timeout=60` (and 120 at ship) on its full-suite test subprocess runs, while this repo's suite takes ~5 minutes. Consequences: the blocking implement GREEN gate could NEVER pass (exit-124 timeout sentinel → treated as "pytest failed"), and the RED gate passed SPURIOUSLY (inverted logic: exit 124 counted as "tests fail as expected").

This PR makes the test-phase timeout env-configurable with a raised default, and teaches the RED gate to treat a timeout as inconclusive:

- New module constant `_DEFAULT_TEST_TIMEOUT = 600` and helper `_test_timeout()` — resolves `KIT_CHECKPOINT_TEST_TIMEOUT` (seconds) at call time; positive int overrides, unset/non-numeric/non-positive fall back to 600.
- Applied at all full-suite test call sites:
  - `_run_python_tests_with_coverage()` — both the `--cov` run and the plain fallback
  - `verify_implement_red()` — all three runner branches (npm / pytest / fallback pytest)
  - `_run_js_tests_in_worktree()` — npm test
  - `verify_implement_test()` — no-runner fallback pytest run
  - `verify_ship_smoke()` — pytest and npm runs (previously 120s)
- `verify_implement_red()` now checks `returncode == 124` BEFORE the generic non-zero → PASS branch in every runner branch: prints `FAIL: RED phase — test run timed out ... (exit 124) — inconclusive, cannot verify genuine RED` and fails the phase.
- `_run()`'s `TimeoutExpired` → exit-124 sentinel contract is unchanged (`test_timeout_returns_124` passes unmodified).

### Scope note (flagged for review)

The issue enumerated three call sites. Two more same-seam sites were absorbed as tech-lead decision from High findings discovered during implementation: `verify_implement_test`'s no-runner fallback (line ~924) and `verify_ship_smoke`'s runs (~1561/1570, which would have deterministically blocked this repo's SHIP phase at 120s). Both are covered by the issue's Goal ("test-related checkpoint timeouts fit the repo's real suite duration"), were done tests-first, and are trivially revertible if the reviewer disagrees.

NOT changed (explicitly out of scope): `_ensure_deps_installed` timeouts, the advisory/blocking tier partition (`test_verify_checkpoint_contract.py` untouched and green), `checkpoint.sh` plumbing, argparse, and the bare `python3 -m pytest` runner choice (switch to `uv run pytest` deferred as follow-up). Known residual: `scripts/verify_gates.py` `run_gate_unit` still hard-codes `timeout=120` — separate file, logged for planner follow-up (blocks ship-phase gates on this repo).

## TDD evidence

- Genuine RED (targeted, before implementation): `uv run pytest tests/test_verify_checkpoint.py -q` → `9 failed, 124 passed` — all 9 failures the intended new tests (commit c9f3b84); Stage-2 additions RED via `-k` → `4 failed, 133 deselected` (commit 5962166).
- GREEN: targeted ISSUE-046 selection `18 passed`; contract file `6 passed`.
- Full suite (worktree, run twice independently): `1133 passed, 2 skipped, 1 warning in ~291s` (main baseline 1116 + 17 new tests).
- Live AC-1 verification: `bash scripts/checkpoint.sh --skill implement --phase test --issue ISSUE-046` executed from inside the worktree (fixed verifier) → `PASS: tests passed`, exit 0, no exit-124 sentinel — the first time this gate has passed on this repo's ~5-minute suite.

## Tests (17 new, all mocked `_run`, no real slow child runs)

- TC-046a GREEN result contract: exit 0 → True, genuine failure → False.
- TC-046b RED matrix: exit 124 → FAIL + "timed out — inconclusive" message; exit 1 → PASS (inverted contract preserved); exit 0 → FAIL.
- TC-046c env override (=45) honored at cov, fallback, RED-python, and npm call sites.
- TC-046d default 600 at GREEN/RED/JS call sites when env unset.
- TC-046e non-numeric env falls back to default without crashing.
- Stage-2: implement-test fallback + ship-smoke default/override matrix.
- Sentinel guard: pre-existing `test_timeout_returns_124` unchanged.

## Rollback

`git revert` — isolated to `scripts/verify_checkpoint.py` + `tests/test_verify_checkpoint.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
