### PR TITLE
[ISSUE-047] Fix verify_gates.py hard-coded 120s unit-gate timeout (and sibling short caps) breaking blocking ship-smoke gates on multi-minute suites

### DIFF
--- a/docs/.review/code-review.md
+++ b/docs/.review/code-review.md
@@ -1,84 +1,135 @@
-# Code Review — ISSUE-046 (PR #54, commit 7476313)
+# Code Review — ISSUE-047 (PR #56, commit 8b7bbaa)
 
 Dimension: code (degraded path — runtime /code-review not invocable) + minimality (folded in).
-Reviewer confidence: High. All 137 tests in tests/test_verify_checkpoint.py pass (4:04 wall);
-the 17 new ISSUE-046 tests run fully mocked in 6.3s with no real child processes or sleeps.
+Reviewer confidence: High. Every finding below was empirically verified in the worktree; both
+touched suites and the full suite are green (81 / 137 / 1154 passed).
 
 ## Verdict
 
-**No blocking findings. Approve.** Three Low, non-blocking findings below.
+**No blocking findings. Approve.** Three Low code findings and one Low minimality finding below —
+all non-blocking suggestions.
 
-**Scope absorption: ACCEPT.** The two absorbed High findings (verify_ship_smoke timeout=120 at
-scripts/verify_checkpoint.py:1592/1601, verify_implement_test no-runner fallback timeout=60 at
-:954) are one-line conversions through the exact `_test_timeout()` seam this issue creates, were
-done tests-first (TC-046f/g, commit 5962166 precedes 7476313), and are trivially revertible.
-Leaving ship-smoke at 120s would deterministically fail this PR's own SHIP phase — the test file
-alone takes ~244s. This is the minimal correct change set, not scope creep; splitting it out
-would add process overhead to re-touch the same seam.
+**Scope absorption: ACCEPT.** The fedf95c isolation fix is (a) genuinely necessary and (b) minimal.
 
-## Verified (with evidence)
+- (a) Necessary — recursion diagnosis independently confirmed by code trace + probes. At base
+  c04b78b, `test_pass_when_pytest_succeeds` / `test_fallback_when_pytest_cov_missing` use
+  `wt_path = str(tmp_path)`, which contains no `issue-001` slug. `_find_worktree_path`
+  (scripts/verify_checkpoint.py:163-181) matches the slug regex against the *path string* from the
+  mocked `git worktree list` output — probe confirmed `pat.search(tmp_style) → False` — so it
+  returns None despite the mock, and `verify_implement_test` (scripts/verify_checkpoint.py:936-938)
+  sets `wt = Path.cwd()` (real repo root). Both tests reach the `if ok:` gate block (mocked pytest
+  returns rc 0), so `_run_verify_gates` (scripts/verify_checkpoint.py:855) imports verify_gates
+  **in-process** and calls `run_applicable_gates` with the real `vg._run` (only `vc._run` was
+  patched). `detect_platforms(repo root)` adds "unit" (tests/ dir exists — probe confirmed), so
+  `run_gate_unit` spawns a real `python3 -m pytest -q --tb=short` over the full suite → recursion;
+  `subprocess.run`'s timeout kill only reaches the direct child, orphaning grandchildren (the
+  observed orphan storm). Consequence for THIS PR: raising the unit-gate default 120→600s makes the
+  un-fixed suite cost ≥ 2×600s in these two tests alone (or fail outright for any timeout value on
+  the blocking path, since the inner recursive suite necessarily exceeds any finite T). The
+  mandatory full-suite test checkpoint could not reasonably pass without this fix.
+- (b) Minimal — exactly the two recursing tests are touched; one `patch.object(vc,
+  "_run_verify_gates", return_value=True)` context each, with `assert_called_once()` preserving the
+  integration point (not a hollow bypass). The other two class tests were checked and do NOT need
+  it: `test_fail_when_pytest_fails` short-circuits before the gate block (ok=False), and
+  `test_runs_in_worktree_cwd`'s slugged tmp worktree has no test files, so `detect_platforms` never
+  adds "unit" and only the cheap load-gate path runs (measured: all 4 class tests < 0.005s).
+- Premise correction confirmed: full suite is 1154 passed in ~13s on this machine (claimed ~21s
+  base — same order of magnitude, machine-dependent). The "~5-minute suite" premise was indeed an
+  artifact of the recursion, not real suite cost.
 
-1. **`_run()` contract preserved** — the diff does not touch `_run`; TimeoutExpired → 124
-   sentinel intact at scripts/verify_checkpoint.py:40-45. AC5's `test_timeout_returns_124`
-   (tests/test_verify_checkpoint.py:1096) is unchanged and passes.
-2. **RED-gate ordering correct in all three branches** — the `returncode == 124` check precedes
-   the `== 0` check and the non-zero → PASS fall-through in npm (:628-630), pytest (:640-642),
-   and fallback pytest (:652-654), each printing a "timed out … inconclusive" FAIL.
-3. **`_test_timeout()` (:58-70)** — reads env at call time; probed empirically: `""`, `"  "`,
-   `"abc"`, `"45.5"`, `"-5"`, `"0"`, `"1e6"` → 600; `"  45  "`, `"+45"` → 45; unset → 600.
-   Matches the documented contract exactly; cannot raise (str input, ValueError caught).
-4. **All test-phase call sites converted** — cov run (:753-761) + pytest-cov fallback (:768),
-   RED ×3 (:627/:639/:651), JS worktree (:798), implement-test fallback (:954), ship-smoke
-   pytest (:1592) + npm (:1601). Full `grep timeout=` audit: every remaining hard-coded timeout
-   is non-test-phase (visual diff :338/:1254, computed styles :1298, layout :1342, structural
-   :1387, figma compliance :1436, debt :1467) or explicitly out of scope (deps install
-   :916/:923/:925). verify_gates.py is ISSUE-047 — not flagged.
-5. **Test quality** — mock side-effects are faithful to the real flows: `_red_side_effect`'s
-   `git worktree` porcelain stub satisfies `_find_worktree_path` (:162-180, slug-boundary match
-   on "issue-001-slug"); `_has_real_tests` (:472) and `_detect_test_runners` (:807) operate on
-   real tmp files written by `_make_red_worktree`; `_default_branch` is patched (necessary — the
-   real impl would return "" under the stub); TC-046f/g patch targets (`_run_verify_gates` :854)
-   exist and match the real call sequence. All behavioral asserts; no hollow tests. TC-046a is
-   the first direct coverage of `_run_python_tests_with_coverage` — not duplicate coverage.
-6. **AC coverage** — AC1: suite passes in 244s < 600s (live-run claim consistent); AC2:
-   `test_red_gate_timeout_124_fails_inconclusive`; AC3: `test_red_gate_genuine_failure_exit_1_passes`;
-   AC4: TC-046c/d (mocked, both override and >= 600 default); AC5: passes unchanged.
+## Verified with evidence
 
-## Findings
+- **Exact semantic parity of the replicated `_test_timeout()`**: scripts/verify_gates.py:63-79 vs
+  scripts/verify_checkpoint.py:58-73 — logic is byte-identical (only the cross-ref comment target
+  differs). Runtime probe over 12 edge inputs (`""`, `"abc"`, `"0"`, `"-5"`, `"600"`, `"900"`,
+  `" 900 "`, `"+900"`, `"9_00"`, `"12.5"`, `"1e3"`, Arabic-Indic `"٦٠٠"`): 12/12 PARITY. Notable
+  shared int() semantics: whitespace/`+` sign/underscores/non-ASCII digits are accepted — identical
+  in both, so "matching ISSUE-046 semantics exactly" (AC-2) holds by construction.
+- **Both call sites converted, nothing else changed**: pytest branch (scripts/verify_gates.py:349-353)
+  and npm branch (:355) both use `timeout=_test_timeout()`. `_run`'s module default `timeout: int = 120`
+  (scripts/verify_gates.py:44) untouched; lint 15s / install 300s / docker 60s / e2e 300s /
+  integration-collect 30s all untouched (diff contains no other timeout edits). rc-127
+  FileNotFoundError path untouched.
+- **verify_checkpoint.py delta is comment-only**: one `# keep in sync with
+  verify_gates.py::_test_timeout` line (scripts/verify_checkpoint.py:65); the mirror comment exists
+  in verify_gates.py:71 — the spec's keep-in-sync cross-references are present in both files.
+- **Test coverage (12 new tests, TC-047a..d)**: TestUnitGateTimeout = 10 (override ×2 branches,
+  unset-default ×2 branches, invalid `"abc"/"0"/"-5"` ×2 branches parametrized);
+  TestTimeoutContract = 2. Assertions are non-hollow: `run_gate_unit` makes exactly one `_run` call
+  per invocation (verified by reading :340-372 — no `_ensure_tool` in the unit gate), so
+  `mock_run.call_args[1]["timeout"]` indexes the pytest/npm call and `timeout` is genuinely passed
+  as a kwarg; npm tests additionally pin `call_args[0][0] == ["npm", "test"]`. Call-time (not
+  import-time) env resolution is covered implicitly and correctly: `vg` is imported at collection,
+  before `monkeypatch.setenv`, so a regression to module-level resolution would fail these tests.
+  Unset tests use `delenv(raising=False)` — robust against a polluted dev environment.
+- **_run timeout-mock contract (AC-3)**: TC-047d patches the real `subprocess.run` with
+  `TimeoutExpired` and asserts rc 124 + exact stderr `"python3: timed out after 600s"`; a second
+  test pins that rc 124 propagates to `status="fail", blocking=True`. Contract intact.
+- **Suites**: `tests/test_verify_gates.py` 81 passed (2.0s); `tests/test_verify_checkpoint.py`
+  137 passed (2.3s); full `tests/` 1154 passed (13.1s). Existing tests pass unchanged (AC-3).
+- **AC-1** (blocking ship-smoke unit gate completes with new default): default is now 600s and the
+  real root cause (recursion) is fixed; full suite at ~13s clears 600s with wide margin. Ship-smoke
+  itself not runnable from this review context, but the mechanics are verified.
 
-```json
-[
-  {
-    "severity": "Low",
-    "title": "GREEN/ship-smoke timeout failures hide the timeout cause — stderr is dropped",
-    "evidence": "scripts/verify_checkpoint.py:776-778 (also :770-772, :800-802, :955-958, :1593-1596): on exit 124, _run sets stdout=\"\" and puts 'timed out after Ns' in stderr, but these failure paths print only 'FAIL: pytest failed (exit 124)' plus stdout[-500:], which is empty on timeout",
-    "fix": "In the generic non-zero failure paths, also echo a tail of result.stderr, or special-case exit 124 with a one-line hint: '(exit 124 = timed out after {timeout}s; raise KIT_CHECKPOINT_TEST_TIMEOUT)'. In-scope-adjacent but non-blocking given the 600s default makes GREEN timeouts rare"
-  },
-  {
-    "severity": "Low",
-    "title": "KIT_CHECKPOINT_TEST_TIMEOUT is undocumented outside the helper docstring",
-    "evidence": "grep of *.md across the worktree: zero mentions of KIT_CHECKPOINT_TEST_TIMEOUT; precedent exists (KIT_SPRINT_MODE is documented in skills/spec/SKILL.md and skills/implement/SKILL.md); the verify_checkpoint.py module docstring (:1-10) documents exit codes but not this knob",
-    "fix": "Add one line to the verify_checkpoint.py module docstring (and optionally skills/implement/SKILL.md): 'KIT_CHECKPOINT_TEST_TIMEOUT — test-phase subprocess timeout in seconds (default 600)'"
-  },
-  {
-    "severity": "Low",
-    "title": "Triplicated identical 124-check block in verify_implement_red; message does not name the runner",
-    "evidence": "scripts/verify_checkpoint.py:628-630, :640-642, :652-654 — three byte-identical print+return blocks; the npm-branch message is indistinguishable from the pytest-branch message",
-    "fix": "Acceptable as-is: it mirrors the function's pre-existing per-branch early-return structure, and extraction saves ~2 net lines (rejected on minimality grounds). If this function is touched again, extract a shared `_red_timeout_check(result, timeout)` and include cmd[0] in the message"
-  }
-]
-```
+## Findings (code)
 
-## Minimality
+1. **[Low] KIT_CHECKPOINT_TEST_TIMEOUT now governs a second script but remains undocumented in any
+   user-facing doc — and the "documented in docs/troubleshooting.md" premise is false.**
+   Evidence: `git grep KIT_CHECKPOINT_TEST_TIMEOUT c04b78b -- '*.md'` and a worktree-wide grep
+   both return only review-artifact files (docs/.review/, docs/review_notes/ISSUE-046.md);
+   docs/troubleshooting.md contains zero mentions at base and at HEAD. ISSUE-046's review already
+   carries an open Low for this; this PR broadens the knob's surface (verify_gates.py unit gate,
+   incl. standalone CLI use) without a doc touch. Recalled lesson 2 applies.
+   Fix: one line in each module docstring ("KIT_CHECKPOINT_TEST_TIMEOUT — test-phase subprocess
+   timeout in seconds, default 600; shared by verify_checkpoint.py and verify_gates.py") plus a
+   short docs/troubleshooting.md entry. Also worth noting there that the "CHECKPOINT" name now
+   also covers the gates script (name reuse is per spec, so doc-only).
 
-Weighed and rejected: extracting the RED 124 triplication (3 call sites, ~2 net lines saved —
-below threshold, and the surrounding ==0/PASS blocks are already per-branch); the redundant
-double-assert `>= 600` + `== _DEFAULT_TEST_TIMEOUT` in TC-046d (3 lines, deliberately encodes
-AC4's ">= 600" plus the exact default — contract pinning, not bloat). `_test_timeout()` has 9
-call sites — not yagni. No dead code, no stdlib reinvention, no speculative config.
+2. **[Low] Known unclamped upper bound is now replicated: huge values crash verify_gates and, in
+   the checkpoint's non-blocking path, silently skip gates.**
+   Evidence: probe in the worktree — `KIT_CHECKPOINT_TEST_TIMEOUT=1000000000` →
+   `vg._test_timeout()` returns 1000000000 and `vg._run(["true"], timeout=...)` raises uncaught
+   `OverflowError: timeout is too large` (vg._run at scripts/verify_gates.py:44-59 catches only
+   TimeoutExpired/FileNotFoundError). Standalone `verify_gates.py` would crash (fail closed); via
+   `_run_verify_gates`'s `except Exception` (scripts/verify_checkpoint.py:869-872) it degrades to
+   WARN and returns True when blocking=False. Exact parity with ISSUE-046 semantics is mandated by
+   AC-2, so inheriting this is by-design — filed as a tracking Low so the eventual clamp (already
+   flagged in docs/review_notes/ISSUE-046.md) is applied to BOTH helpers; the keep-in-sync
+   comments make that cheap. Local-env-only, no attack vector → Low.
 
-```json
-[]
-```
+3. **[Low] Comment-only sync guarantee: no test enforces parity between the two `_test_timeout`
+   helpers.**
+   Evidence: sync is guaranteed only by the cross-ref comments (scripts/verify_gates.py:71,
+   scripts/verify_checkpoint.py:65); my 12-input parity probe passes today, but silent drift in
+   either file would not fail any test. The spec chose comment-based sync, so this is a
+   nice-to-have hardening, not a gap in the mandated work.
+   Fix: a ~6-line parametrized test importing both modules and asserting
+   `vg._test_timeout() == vc._test_timeout()` across the edge inputs ("", "abc", "0", "-5", "900").
 
-Lean already. Ship.
+## Findings (minimality)
+
+- tests/test_verify_gates.py:322-380: shrink — 6 TestUnitGateTimeout methods are 3 near-identical
+  pytest/npm pairs differing only in project setup → parametrize over branch (fixture writing
+  pyproject.toml vs package.json) × env value; same 10 cases, ~35 fewer lines, per-case pytest ids
+  preserved. Both branches stay covered, so AC-2 is unaffected.
+
+Everything else is lean: the helper replication, constant, docstring, and cross-ref comments are
+spec-mandated; the TC-047d pair guards AC-3 end-to-end and does not duplicate the existing rc-1
+fail-path test.
+
+Net removable lines: ~35 (report-only; do not apply during review).
+
+## Self-Review
+
+- Severity re-assessment: all four findings re-checked against impact — none blocks; the overflow
+  finding stays Low per the same rationale ISSUE-046's audit used (local env control required,
+  blocking path fails closed).
+- False-positive check: one candidate finding was dropped after empirical disproof —
+  `test_runs_in_worktree_cwd` does NOT spawn a real pytest (tmp worktree has no test files, so
+  "unit" is never detected; class runtime < 5ms). Doc-gap and overflow findings were verified by
+  grep and runtime probe rather than assumed.
+- Blind-spot scan: re-checked error handling (127 path untouched), hollow-assertion risk
+  (call_args indexing valid — single `_run` call in unit gate), import-time vs call-time env
+  resolution (covered), and other-gate timeout drift (none in diff).
+- AC verification: AC-1/2/3 each verified above with evidence.
+- Confidence: High.

--- a/docs/.review/findings.json
+++ b/docs/.review/findings.json
@@ -1,48 +1,49 @@
 {
-  "pr_number": "54",
+  "pr_number": 56,
   "code_source": "reviewer-degraded",
   "security_source": "reviewer-degraded",
   "code_findings": [
     {
       "severity": "Low",
-      "title": "GREEN/ship-smoke timeout failures hide the timeout cause — stderr is dropped",
-      "evidence": "scripts/verify_checkpoint.py:776-778 (also :770-772, :800-802, :955-958, :1593-1596): on exit 124, _run sets stdout=\"\" and puts 'timed out after Ns' in stderr, but these failure paths print only 'FAIL: pytest failed (exit 124)' plus stdout[-500:], which is empty on timeout",
-      "fix": "In the generic non-zero failure paths, also echo a tail of result.stderr, or special-case exit 124 with a one-line hint: '(exit 124 = timed out after {timeout}s; raise KIT_CHECKPOINT_TEST_TIMEOUT)'. In-scope-adjacent but non-blocking given the 600s default makes GREEN timeouts rare"
+      "title": "KIT_CHECKPOINT_TEST_TIMEOUT now governs a second script but remains undocumented in any user-facing doc — and the \"documented in docs/troubleshooting.md\" premise is false",
+      "evidence": "`git grep KIT_CHECKPOINT_TEST_TIMEOUT c04b78b -- '*.md'` and a worktree-wide grep both return only review-artifact files (docs/.review/, docs/review_notes/ISSUE-046.md); docs/troubleshooting.md contains zero mentions at base and at HEAD. ISSUE-046's review already carries an open Low for this; this PR broadens the knob's surface (verify_gates.py unit gate, incl. standalone CLI use) without a doc touch. Recalled lesson 2 applies.",
+      "fix": "One line in each module docstring (\"KIT_CHECKPOINT_TEST_TIMEOUT — test-phase subprocess timeout in seconds, default 600; shared by verify_checkpoint.py and verify_gates.py\") plus a short docs/troubleshooting.md entry. Also worth noting there that the \"CHECKPOINT\" name now also covers the gates script (name reuse is per spec, so doc-only)."
     },
     {
       "severity": "Low",
-      "title": "KIT_CHECKPOINT_TEST_TIMEOUT is undocumented outside the helper docstring",
-      "evidence": "grep of *.md across the worktree: zero mentions of KIT_CHECKPOINT_TEST_TIMEOUT; precedent exists (KIT_SPRINT_MODE is documented in skills/spec/SKILL.md and skills/implement/SKILL.md); the verify_checkpoint.py module docstring (:1-10) documents exit codes but not this knob",
-      "fix": "Add one line to the verify_checkpoint.py module docstring (and optionally skills/implement/SKILL.md): 'KIT_CHECKPOINT_TEST_TIMEOUT — test-phase subprocess timeout in seconds (default 600)'"
+      "title": "Known unclamped upper bound is now replicated: huge values crash verify_gates and, in the checkpoint's non-blocking path, silently skip gates",
+      "evidence": "Probe in the worktree — KIT_CHECKPOINT_TEST_TIMEOUT=1000000000 → vg._test_timeout() returns 1000000000 and vg._run([\"true\"], timeout=...) raises uncaught OverflowError: timeout is too large (vg._run at scripts/verify_gates.py:44-59 catches only TimeoutExpired/FileNotFoundError). Standalone verify_gates.py would crash (fail closed); via _run_verify_gates's except Exception (scripts/verify_checkpoint.py:869-872) it degrades to WARN and returns True when blocking=False. Exact parity with ISSUE-046 semantics is mandated by AC-2, so inheriting this is by-design — filed as a tracking Low so the eventual clamp (already flagged in docs/review_notes/ISSUE-046.md) is applied to BOTH helpers; the keep-in-sync comments make that cheap. Local-env-only, no attack vector → Low.",
+      "fix": "Tracking note: when ISSUE-046's open Low (upper clamp) is addressed, apply it to BOTH _test_timeout helpers — the keep-in-sync comments make this a paired one-line change."
     },
     {
       "severity": "Low",
-      "title": "Triplicated identical 124-check block in verify_implement_red; message does not name the runner",
-      "evidence": "scripts/verify_checkpoint.py:628-630, :640-642, :652-654 — three byte-identical print+return blocks; the npm-branch message is indistinguishable from the pytest-branch message",
-      "fix": "Acceptable as-is: it mirrors the function's pre-existing per-branch early-return structure, and extraction saves ~2 net lines (rejected on minimality grounds). If this function is touched again, extract a shared `_red_timeout_check(result, timeout)` and include cmd[0] in the message"
+      "title": "Comment-only sync guarantee: no test enforces parity between the two _test_timeout helpers",
+      "evidence": "Sync is guaranteed only by the cross-ref comments (scripts/verify_gates.py:71, scripts/verify_checkpoint.py:65); my 12-input parity probe passes today, but silent drift in either file would not fail any test. The spec chose comment-based sync, so this is a nice-to-have hardening, not a gap in the mandated work.",
+      "fix": "A ~6-line parametrized test importing both modules and asserting vg._test_timeout() == vc._test_timeout() across the edge inputs (\"\", \"abc\", \"0\", \"-5\", \"900\")."
     },
     {
       "severity": "Low",
-      "title": "[pre-existing, out of scope — ISSUE-047] verify_gates.py run_gate_unit hard-codes timeout=120 on the full suite; observed during this review's test checkpoint",
-      "evidence": "Observed live in the review test-phase checkpoint output (exit 0, non-blocking here): 'PASS: tests passed' followed by 'GATE FAIL: unit [blocking] (120.1s) / python3: timed out after 120s'. This is scripts/verify_gates.py (separate file, NOT touched by PR #54) — the known pre-existing bug already filed as ISSUE-047 (P0, Depends-On: ISSUE-046). Not a regression from this PR.",
-      "fix": "No action in this PR (scope discipline — issue Scope Out names verify_gates.py explicitly). ISSUE-047 fixes it. Known consequence: ISSUE-046's own SHIP smoke checkpoint is expected to fail on this until ISSUE-047 lands."
-    },
-    {
-      "severity": "Low",
-      "title": "[debt] KIT-DEBT ledger has 3 no-trigger markers (silent-rot risk) — all harvester-self-referential, none from this PR",
-      "evidence": "review debt checkpoint harvest (advisory): scripts/debt_harvest.py:44 (module docstring format example), tests/test_debt_harvest.py:27 and :59 (deliberate no-trigger test fixtures); total 14 markers, 3 no-trigger, 1 malformed — none introduced or touched by PR #54",
-      "fix": "Pre-existing and self-referential (harvester's own docs/tests): consider teaching debt_harvest.py to exclude its own docstring examples and test fixture strings from the ledger so real no-trigger debt stands out"
+      "title": "[debt] KIT-DEBT ledger has 3 no-trigger markers (silent-rot risk) — all harvester self-references, none introduced by this PR",
+      "evidence": "checkpoint.sh --skill review --phase debt --issue ISSUE-047: total 14 markers, 3 no-trigger (scripts/debt_harvest.py:44 docstring format example; tests/test_debt_harvest.py:27 and :59 deliberate no-trigger test fixtures), 1 malformed (tests/test_debt_harvest.py:35 deliberate fixture). Identical state to the ISSUE-046 review's ledger — pre-existing, not from this diff.",
+      "fix": "No action in this PR. If the harvester grows an ignore-mechanism for its own fixtures/docstring examples, these false positives disappear from the ledger."
     }
   ],
   "security_findings": [
     {
       "severity": "Low",
-      "title": "No upper bound on KIT_CHECKPOINT_TEST_TIMEOUT: values >= ~1e9 crash the verifier with unhandled OverflowError; large-but-valid values silently remove the hang bound",
-      "evidence": "scripts/verify_checkpoint.py:70 `return value if value > 0 else _DEFAULT_TEST_TIMEOUT` — no upper clamp. Verified: KIT_CHECKPOINT_TEST_TIMEOUT=10**9 -> `OverflowError: timeout is too large` inside subprocess.run (uncaught by _run, which only handles TimeoutExpired/FileNotFoundError at scripts/verify_checkpoint.py:40-52); 10**6 works but effectively disables the timeout. Requires local env control, fails closed (crash = checkpoint failure), no gate bypass — hence Low, not Medium.",
-      "fix": "Clamp in _test_timeout(), e.g. `return min(value, 86400) if value > 0 else _DEFAULT_TEST_TIMEOUT` (optionally print a WARN when clamping). Alternatively catch OverflowError alongside TimeoutExpired in _run, but the clamp is simpler and also restores a meaningful hang bound."
+      "title": "No upper bound on KIT_CHECKPOINT_TEST_TIMEOUT in verify_gates.py: values >= ~1e9 raise unhandled OverflowError inside subprocess.run (fails closed); large-but-valid values silently remove the unit gate's hang bound",
+      "evidence": "scripts/verify_gates.py:79 `return value if value > 0 else _DEFAULT_TEST_TIMEOUT` — no upper clamp; scripts/verify_gates.py:49-60 — `_run` catches only TimeoutExpired and FileNotFoundError, so OverflowError propagates. Reproduced in the worktree: `vg._run([\"true\"], timeout=10**9)` -> `OverflowError: timeout is too large`; `10**12` -> `timestamp too large to convert to C _PyTime_t`. Containment verified fail-closed on both paths: CLI -> unhandled traceback -> exit 1 (blocking-failure semantics); in-process -> caught by `except Exception` at scripts/verify_checkpoint.py:870-872 -> checkpoint FAIL when blocking=True. Values just under the threshold (e.g. 1e8 s ~ 3 years) effectively disable the hang bound for the blocking unit gate. Requires local env control, no gate bypass, crash fails closed — hence Low.",
+      "fix": "Clamp in _test_timeout(), e.g. `return min(value, 86400) if value > 0 else _DEFAULT_TEST_TIMEOUT` (optionally WARN when clamping), and apply the same clamp to the mirrored helper in verify_checkpoint.py (the '# keep in sync' comment makes this a single change done twice). Alternatively catch OverflowError alongside TimeoutExpired in _run, but the clamp is simpler and also restores a meaningful hang bound."
     }
   ],
-  "minimality_findings": [],
+  "minimality_findings": [
+    {
+      "severity": "Low",
+      "title": "[shrink] TestUnitGateTimeout's 6 methods are 3 near-identical pytest/npm pairs — parametrize over branch",
+      "evidence": "tests/test_verify_gates.py:322-380: shrink — 6 TestUnitGateTimeout methods are 3 near-identical pytest/npm pairs differing only in project setup → parametrize over branch (fixture writing pyproject.toml vs package.json) × env value",
+      "fix": "Parametrize; same 10 cases, ~35 fewer lines, per-case pytest ids preserved. Both branches stay covered, so AC-2 is unaffected. Net removable lines: ~35 (report-only)."
+    }
+  ],
   "ui_findings": null,
   "design_findings": null,
   "a11y_findings": null,

--- a/docs/.review/security-review.md
+++ b/docs/.review/security-review.md
@@ -1,18 +1,20 @@
-# Security Review — PR #54 (ISSUE-046, degraded path)
+# Security Review — ISSUE-047 (PR #56, commit 8b7bbaa)
 
-Scope: `git diff main...HEAD` at 7476313 — scripts/verify_checkpoint.py (+49/-9), tests/test_verify_checkpoint.py (+311). Local/CI developer tooling, not user-facing.
+Dimension: security (degraded path — runtime /security-review not invocable)
+
+Scope: `git diff c04b78b..HEAD` — scripts/verify_gates.py (+25/-2: `_DEFAULT_TEST_TIMEOUT`, `_test_timeout()`, two `run_gate_unit` call sites), scripts/verify_checkpoint.py (+1 comment), tests/test_verify_gates.py (+94), tests/test_verify_checkpoint.py (+14/-2). Local/CI developer tooling, not user-facing.
 
 ## Verdict
 
-Clean on every high-impact axis. Verified in the actual code, not just the diff description:
+Clean on every high-impact axis. One Low-severity finding — the same no-upper-bound gap ISSUE-046's review found in the identical `verify_checkpoint.py` pattern, re-verified here against verify_gates.py's own exception handling and both invocation paths. Nothing blocking.
 
-- **Injection**: `KIT_CHECKPOINT_TEST_TIMEOUT` flows through `int()` (scripts/verify_checkpoint.py:65-70) and only into the `timeout=` kwarg of `subprocess.run` (scripts/verify_checkpoint.py:38-39). It never reaches argv or a shell string. All call sites use static list-form argv; `grep shell=True` over the file returns nothing. No new subprocess call sites introduced.
-- **Input validation**: probed empirically — empty, `"abc"`, `"-5"`, `"0"`, `"inf"`, `"4.5"`, unicode digits (`"٦٠٠"` → 600, harmless int), whitespace, underscores, and 5000-digit strings (Python 3.11 int-str limit raises ValueError → caught) all resolve safely to the default or a plain int. `timeout=0` ("disable" path in `_run`) is unreachable via the env var since non-positive maps to the default. One robustness gap remains (finding below).
-- **Fail direction**: the one crash path found is fail-closed — an unhandled exception in the verifier fails the checkpoint; no gate-bypass path exists. The new returncode==124 branch also fails closed (`return False`).
-- **Secrets / dependencies / deserialization / network / XSS / misconfig**: nothing added or touched by this diff.
-- **DoS from raised defaults (60/120s → 600s)**: deliberate, documented tradeoff (suite runs ~4.5 min); a hung suite now occupies a runner up to 10 min, bounded in practice by CI job-level timeouts. Not a finding.
+Verified in the worktree code, not just the diff description:
 
-One Low-severity robustness finding; nothing blocking.
+- **Injection**: `KIT_CHECKPOINT_TEST_TIMEOUT` flows through `int()` (scripts/verify_gates.py:74-79) and only into the `timeout=` kwarg of `_run` → `subprocess.run` (scripts/verify_gates.py:349-355, 44-48). It never reaches argv or a shell string. `grep 'shell=True|os.system|eval(|exec('` over both changed scripts returns nothing. The only place the value is stringified is the `f"{prog}: timed out after {timeout}s"` stderr message — plain output, and by that point it is a plain int. No new subprocess call sites introduced.
+- **Input validation**: probed empirically by executing `_test_timeout()` in the worktree — `""`, `"abc"`, `"0"`, `"-5"`, `"600.5"` all fall back to 600; `" 900 "`, `"+900"`, `"1_000"` parse as plain ints. Fail direction on bad input is fail-safe (default), never crash, never 0. The `timeout=0` → `None` ("no timeout") branch in `_run` (scripts/verify_gates.py:47) is unreachable via the env var since non-positive maps to the default — confirmed by TC-047c tests and by direct execution.
+- **Denial / gate bypass**: no fail-open path. A tiny valid value (e.g. `1`) makes the unit gate time out → rc 124 → `status="fail"`, `blocking=True` (scripts/verify_gates.py:366) — fails closed. A huge value crashes or removes the hang bound (finding below) but can never convert a failing test run into a pass. Crash containment verified on both invocation paths: (a) CLI `main()` — unhandled exception → interpreter exit 1, which callers interpret as "blocking gate failed"; (b) in-process via `verify_checkpoint._run_verify_gates` (scripts/verify_checkpoint.py:868-872) — `except Exception` catches OverflowError and returns `not blocking`, i.e. FAIL when blocking=True. The blocking=False implement-phase path warns and continues, but in that mode gate failures are warnings by design, so nothing is bypassed that would otherwise block.
+- **Secrets / dependencies / deserialization / XSS / misconfig**: nothing added or touched by this diff. No new dependencies.
+- **Tests execute nothing real**: confirmed. `TestUnitGateTimeout` and `TestTimeoutContract.test_gate_fails_when_run_times_out` patch `vg._run`; `test_run_returns_rc_124_and_timed_out_stderr_on_timeout` patches global `subprocess.run` before calling the real `_run`, so no process spawns. Env mutation uses `monkeypatch` (auto-restored). The `test_verify_checkpoint.py` changes patch `_run_verify_gates`, which *removes* a pre-existing real-execution hazard (accidental recursive full-suite pytest spawn from the repo root) — a test-safety improvement, not a finding.
 
 ## Findings
 
@@ -20,16 +22,17 @@ One Low-severity robustness finding; nothing blocking.
 [
   {
     "severity": "Low",
-    "title": "No upper bound on KIT_CHECKPOINT_TEST_TIMEOUT: values >= ~1e9 crash the verifier with unhandled OverflowError; large-but-valid values silently remove the hang bound",
-    "evidence": "scripts/verify_checkpoint.py:70 `return value if value > 0 else _DEFAULT_TEST_TIMEOUT` — no upper clamp. Verified: KIT_CHECKPOINT_TEST_TIMEOUT=10**9 -> `OverflowError: timeout is too large` inside subprocess.run (uncaught by _run, which only handles TimeoutExpired/FileNotFoundError at scripts/verify_checkpoint.py:40-52); 10**6 works but effectively disables the timeout. Requires local env control, fails closed (crash = checkpoint failure), no gate bypass — hence Low, not Medium.",
-    "fix": "Clamp in _test_timeout(), e.g. `return min(value, 86400) if value > 0 else _DEFAULT_TEST_TIMEOUT` (optionally print a WARN when clamping). Alternatively catch OverflowError alongside TimeoutExpired in _run, but the clamp is simpler and also restores a meaningful hang bound."
+    "title": "No upper bound on KIT_CHECKPOINT_TEST_TIMEOUT in verify_gates.py: values >= ~1e9 raise unhandled OverflowError inside subprocess.run (fails closed); large-but-valid values silently remove the unit gate's hang bound",
+    "evidence": "scripts/verify_gates.py:79 `return value if value > 0 else _DEFAULT_TEST_TIMEOUT` — no upper clamp; scripts/verify_gates.py:49-60 — `_run` catches only TimeoutExpired and FileNotFoundError, so OverflowError propagates. Reproduced in the worktree: `vg._run([\"true\"], timeout=10**9)` -> `OverflowError: timeout is too large`; `10**12` -> `timestamp too large to convert to C _PyTime_t`. Containment verified fail-closed on both paths: CLI -> unhandled traceback -> exit 1 (blocking-failure semantics); in-process -> caught by `except Exception` at scripts/verify_checkpoint.py:870-872 -> checkpoint FAIL when blocking=True. Values just under the threshold (e.g. 1e8 s ~ 3 years) effectively disable the hang bound for the blocking unit gate. Requires local env control, no gate bypass, crash fails closed — hence Low.",
+    "fix": "Clamp in _test_timeout(), e.g. `return min(value, 86400) if value > 0 else _DEFAULT_TEST_TIMEOUT` (optionally WARN when clamping), and apply the same clamp to the mirrored helper in verify_checkpoint.py (the '# keep in sync' comment makes this a single change done twice). Alternatively catch OverflowError alongside TimeoutExpired in _run, but the clamp is simpler and also restores a meaningful hang bound."
   }
 ]
 ```
 
 ## Self-review
 
-- Severity re-checked: the crash needs env control on the developer's own machine/runner (anyone with that can already run arbitrary code) and fails closed — Low is impact-honest.
-- False-positive check: both the OverflowError (10**9 and 10**18 variants) and the fail-back cases were reproduced by executing `_test_timeout()`/`_run()` directly, not inferred.
-- Blind-spot re-scan: re-read the diff for shell usage, string-built commands, secrets, deserialization of the env value, and log injection via the f-string 124 messages (value is an int by print time) — nothing found.
-- Confidence: High — small diff, every claim executed against the worktree code.
+- Severity re-checked: exploitation requires setting an env var on the developer's own machine/runner — anyone with that access can already run arbitrary code or skip the gate entirely; the crash fails closed and no input value can flip a failing gate to pass. Low is impact-honest; matches the ISSUE-046 precedent rating for the identical pattern.
+- False-positive check: every claim was executed against the worktree code (parsing table, OverflowError at 1e9/1e12/1e20, harmless `true` command), and both crash-containment paths were read in source, not assumed from the ISSUE-046 report.
+- Blind-spot re-scan (security dimension only): re-read the diff for shell usage, string-built commands, secrets, deserialization of the env value, new dependencies, and log injection via the rc-124 f-string (int by print time) — nothing found. Considered TOCTOU (env read once per gate at call time — fine) and tiny-timeout DoS (fails closed).
+- AC check: env override, 600 default, invalid-value fallback, and fully mocked tests are all present in the diff; no acceptance criterion introduces a security regression.
+- Confidence: High — small diff, the env value's full data flow was traced end to end and behavior verified empirically.

--- a/docs/review_notes/ISSUE-047.md
+++ b/docs/review_notes/ISSUE-047.md
@@ -1,0 +1,33 @@
+# Review Notes — PR #56
+
+## Code Review
+_Source: reviewer-degraded_
+
+- **[Low] KIT_CHECKPOINT_TEST_TIMEOUT now governs a second script but remains undocumented in any user-facing doc — and the "documented in docs/troubleshooting.md" premise is false**
+  Evidence: `git grep KIT_CHECKPOINT_TEST_TIMEOUT c04b78b -- '*.md'` and a worktree-wide grep both return only review-artifact files (docs/.review/, docs/review_notes/ISSUE-046.md); docs/troubleshooting.md contains zero mentions at base and at HEAD. ISSUE-046's review already carries an open Low for this; this PR broadens the knob's surface (verify_gates.py unit gate, incl. standalone CLI use) without a doc touch. Recalled lesson 2 applies.
+  Fix: One line in each module docstring ("KIT_CHECKPOINT_TEST_TIMEOUT — test-phase subprocess timeout in seconds, default 600; shared by verify_checkpoint.py and verify_gates.py") plus a short docs/troubleshooting.md entry. Also worth noting there that the "CHECKPOINT" name now also covers the gates script (name reuse is per spec, so doc-only).
+
+- **[Low] Known unclamped upper bound is now replicated: huge values crash verify_gates and, in the checkpoint's non-blocking path, silently skip gates**
+  Evidence: Probe in the worktree — KIT_CHECKPOINT_TEST_TIMEOUT=1000000000 → vg._test_timeout() returns 1000000000 and vg._run(["true"], timeout=...) raises uncaught OverflowError: timeout is too large (vg._run at scripts/verify_gates.py:44-59 catches only TimeoutExpired/FileNotFoundError). Standalone verify_gates.py would crash (fail closed); via _run_verify_gates's except Exception (scripts/verify_checkpoint.py:869-872) it degrades to WARN and returns True when blocking=False. Exact parity with ISSUE-046 semantics is mandated by AC-2, so inheriting this is by-design — filed as a tracking Low so the eventual clamp (already flagged in docs/review_notes/ISSUE-046.md) is applied to BOTH helpers; the keep-in-sync comments make that cheap. Local-env-only, no attack vector → Low.
+  Fix: Tracking note: when ISSUE-046's open Low (upper clamp) is addressed, apply it to BOTH _test_timeout helpers — the keep-in-sync comments make this a paired one-line change.
+
+- **[Low] Comment-only sync guarantee: no test enforces parity between the two _test_timeout helpers**
+  Evidence: Sync is guaranteed only by the cross-ref comments (scripts/verify_gates.py:71, scripts/verify_checkpoint.py:65); my 12-input parity probe passes today, but silent drift in either file would not fail any test. The spec chose comment-based sync, so this is a nice-to-have hardening, not a gap in the mandated work.
+  Fix: A ~6-line parametrized test importing both modules and asserting vg._test_timeout() == vc._test_timeout() across the edge inputs ("", "abc", "0", "-5", "900").
+
+- **[Low] [debt] KIT-DEBT ledger has 3 no-trigger markers (silent-rot risk) — all harvester self-references, none introduced by this PR**
+  Evidence: checkpoint.sh --skill review --phase debt --issue ISSUE-047: total 14 markers, 3 no-trigger (scripts/debt_harvest.py:44 docstring format example; tests/test_debt_harvest.py:27 and :59 deliberate no-trigger test fixtures), 1 malformed (tests/test_debt_harvest.py:35 deliberate fixture). Identical state to the ISSUE-046 review's ledger — pre-existing, not from this diff.
+  Fix: No action in this PR. If the harvester grows an ignore-mechanism for its own fixtures/docstring examples, these false positives disappear from the ledger.
+
+## Security Findings
+_Source: reviewer-degraded_
+
+- **[Low] No upper bound on KIT_CHECKPOINT_TEST_TIMEOUT in verify_gates.py: values >= ~1e9 raise unhandled OverflowError inside subprocess.run (fails closed); large-but-valid values silently remove the unit gate's hang bound**
+  Evidence: scripts/verify_gates.py:79 `return value if value > 0 else _DEFAULT_TEST_TIMEOUT` — no upper clamp; scripts/verify_gates.py:49-60 — `_run` catches only TimeoutExpired and FileNotFoundError, so OverflowError propagates. Reproduced in the worktree: `vg._run(["true"], timeout=10**9)` -> `OverflowError: timeout is too large`; `10**12` -> `timestamp too large to convert to C _PyTime_t`. Containment verified fail-closed on both paths: CLI -> unhandled traceback -> exit 1 (blocking-failure semantics); in-process -> caught by `except Exception` at scripts/verify_checkpoint.py:870-872 -> checkpoint FAIL when blocking=True. Values just under the threshold (e.g. 1e8 s ~ 3 years) effectively disable the hang bound for the blocking unit gate. Requires local env control, no gate bypass, crash fails closed — hence Low.
+  Fix: Clamp in _test_timeout(), e.g. `return min(value, 86400) if value > 0 else _DEFAULT_TEST_TIMEOUT` (optionally WARN when clamping), and apply the same clamp to the mirrored helper in verify_checkpoint.py (the '# keep in sync' comment makes this a single change done twice). Alternatively catch OverflowError alongside TimeoutExpired in _run, but the clamp is simpler and also restores a meaningful hang bound.
+
+## Over-Engineering
+
+- **[Low] [shrink] TestUnitGateTimeout's 6 methods are 3 near-identical pytest/npm pairs — parametrize over branch**
+  Evidence: tests/test_verify_gates.py:322-380: shrink — 6 TestUnitGateTimeout methods are 3 near-identical pytest/npm pairs differing only in project setup → parametrize over branch (fixture writing pyproject.toml vs package.json) × env value
+  Fix: Parametrize; same 10 cases, ~35 fewer lines, per-case pytest ids preserved. Both branches stay covered, so AC-2 is unaffected. Net removable lines: ~35 (report-only).

--- a/scripts/verify_checkpoint.py
+++ b/scripts/verify_checkpoint.py
@@ -62,6 +62,7 @@ def _test_timeout() -> int:
     overrides the default; unset, non-numeric, or non-positive values fall
     back to _DEFAULT_TEST_TIMEOUT.
     """
+    # keep in sync with verify_gates.py::_test_timeout
     raw = os.environ.get("KIT_CHECKPOINT_TEST_TIMEOUT", "")
     try:
         value = int(raw)

--- a/scripts/verify_gates.py
+++ b/scripts/verify_gates.py
@@ -60,6 +60,25 @@ def _run(cmd: list[str], timeout: int = 120, **kwargs) -> subprocess.CompletedPr
         return mock
 
 
+_DEFAULT_TEST_TIMEOUT = 600  # seconds — default for test-phase subprocess runs
+
+
+def _test_timeout() -> int:
+    """Resolve the test-phase timeout at call time.
+
+    Reads KIT_CHECKPOINT_TEST_TIMEOUT (seconds). A valid positive integer
+    overrides the default; unset, non-numeric, or non-positive values fall
+    back to _DEFAULT_TEST_TIMEOUT.
+    """
+    # keep in sync with verify_checkpoint.py::_test_timeout
+    raw = os.environ.get("KIT_CHECKPOINT_TEST_TIMEOUT", "")
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_TEST_TIMEOUT
+    return value if value > 0 else _DEFAULT_TEST_TIMEOUT
+
+
 def _tail(text: str, max_chars: int = 2000) -> str:
     """Return the last max_chars characters of text."""
     return text[-max_chars:] if len(text) > max_chars else text
@@ -327,9 +346,13 @@ def run_gate_unit(project_path: Path, **_kwargs) -> GateResult:
     # Decide: pytest or npm test
     pkg_json = pp / "package.json"
     if (pp / "pyproject.toml").exists() or (pp / "tests").is_dir() or list(pp.glob("test_*.py")):
-        result = _run(["python3", "-m", "pytest", "-q", "--tb=short"], timeout=120, cwd=str(pp))
+        result = _run(
+            ["python3", "-m", "pytest", "-q", "--tb=short"],
+            timeout=_test_timeout(),
+            cwd=str(pp),
+        )
     elif pkg_json.exists():
-        result = _run(["npm", "test"], timeout=120, cwd=str(pp))
+        result = _run(["npm", "test"], timeout=_test_timeout(), cwd=str(pp))
     else:
         return GateResult(
             gate="unit",

--- a/tests/test_verify_checkpoint.py
+++ b/tests/test_verify_checkpoint.py
@@ -458,7 +458,13 @@ class TestVerifyImplementTest:
             return _mock_run(0)
 
         with patch.object(vc, "_run", side_effect=side_effect):
-            assert vc.verify_implement_test("ISSUE-001") is True
+            # Guard (TC-047g): without this patch, the slug-less worktree mock
+            # makes _find_worktree_path return None -> wt = Path.cwd() (real
+            # repo root) -> _run_verify_gates spawns a real recursive
+            # full-suite pytest in-process.
+            with patch.object(vc, "_run_verify_gates", return_value=True) as mock_gates:
+                assert vc.verify_implement_test("ISSUE-001") is True
+            mock_gates.assert_called_once()
 
     def test_fail_when_pytest_fails(self, tmp_path):
         wt_path = str(tmp_path)
@@ -512,7 +518,13 @@ class TestVerifyImplementTest:
             return _mock_run(0)  # Fallback plain pytest passes
 
         with patch.object(vc, "_run", side_effect=side_effect):
-            assert vc.verify_implement_test("ISSUE-001") is True
+            # Guard (TC-047g): without this patch, the slug-less worktree mock
+            # makes _find_worktree_path return None -> wt = Path.cwd() (real
+            # repo root) -> _run_verify_gates spawns a real recursive
+            # full-suite pytest in-process.
+            with patch.object(vc, "_run_verify_gates", return_value=True) as mock_gates:
+                assert vc.verify_implement_test("ISSUE-001") is True
+            mock_gates.assert_called_once()
 
 
 class TestVerifyImplementPush:

--- a/tests/test_verify_gates.py
+++ b/tests/test_verify_gates.py
@@ -315,6 +315,100 @@ class TestRunGateUnit:
         assert result.status == "skip"
 
 
+# ── TestUnitGateTimeout (ISSUE-047: TC-047a..c) ──────────────────────
+
+
+class TestUnitGateTimeout:
+    """Unit gate must resolve its subprocess timeout via KIT_CHECKPOINT_TEST_TIMEOUT."""
+
+    # TC-047a: env override applies (both branches)
+
+    @patch.object(vg, "_run")
+    def test_env_override_applies_to_pytest_branch(self, mock_run, tmp_path, monkeypatch):
+        monkeypatch.setenv("KIT_CHECKPOINT_TEST_TIMEOUT", "900")
+        (tmp_path / "pyproject.toml").write_text("")
+        mock_run.return_value = _mock_run(0, "3 passed\n", "")
+        vg.run_gate_unit(tmp_path)
+        assert mock_run.call_args[1]["timeout"] == 900
+
+    @patch.object(vg, "_run")
+    def test_env_override_applies_to_npm_branch(self, mock_run, tmp_path, monkeypatch):
+        monkeypatch.setenv("KIT_CHECKPOINT_TEST_TIMEOUT", "900")
+        _write_package_json(tmp_path, {"jest": "^29.0.0"})
+        mock_run.return_value = _mock_run(0, "Tests: 5 passed\n", "")
+        vg.run_gate_unit(tmp_path)
+        assert mock_run.call_args[0][0] == ["npm", "test"]
+        assert mock_run.call_args[1]["timeout"] == 900
+
+    # TC-047b: env unset → 600s default (both branches)
+
+    @patch.object(vg, "_run")
+    def test_default_600s_when_env_unset_pytest_branch(self, mock_run, tmp_path, monkeypatch):
+        monkeypatch.delenv("KIT_CHECKPOINT_TEST_TIMEOUT", raising=False)
+        (tmp_path / "pyproject.toml").write_text("")
+        mock_run.return_value = _mock_run(0, "3 passed\n", "")
+        vg.run_gate_unit(tmp_path)
+        assert mock_run.call_args[1]["timeout"] == 600
+
+    @patch.object(vg, "_run")
+    def test_default_600s_when_env_unset_npm_branch(self, mock_run, tmp_path, monkeypatch):
+        monkeypatch.delenv("KIT_CHECKPOINT_TEST_TIMEOUT", raising=False)
+        _write_package_json(tmp_path, {"jest": "^29.0.0"})
+        mock_run.return_value = _mock_run(0, "Tests: 5 passed\n", "")
+        vg.run_gate_unit(tmp_path)
+        assert mock_run.call_args[0][0] == ["npm", "test"]
+        assert mock_run.call_args[1]["timeout"] == 600
+
+    # TC-047c: non-numeric / non-positive → 600s default, no crash
+
+    @pytest.mark.parametrize("bad_value", ["abc", "0", "-5"])
+    @patch.object(vg, "_run")
+    def test_invalid_env_falls_back_to_default_pytest_branch(
+        self, mock_run, bad_value, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("KIT_CHECKPOINT_TEST_TIMEOUT", bad_value)
+        (tmp_path / "pyproject.toml").write_text("")
+        mock_run.return_value = _mock_run(0, "3 passed\n", "")
+        vg.run_gate_unit(tmp_path)
+        assert mock_run.call_args[1]["timeout"] == 600
+
+    @pytest.mark.parametrize("bad_value", ["abc", "0", "-5"])
+    @patch.object(vg, "_run")
+    def test_invalid_env_falls_back_to_default_npm_branch(
+        self, mock_run, bad_value, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("KIT_CHECKPOINT_TEST_TIMEOUT", bad_value)
+        _write_package_json(tmp_path, {"jest": "^29.0.0"})
+        mock_run.return_value = _mock_run(0, "Tests: 5 passed\n", "")
+        vg.run_gate_unit(tmp_path)
+        assert mock_run.call_args[1]["timeout"] == 600
+
+
+# ── TestTimeoutContract (ISSUE-047: TC-047d) ─────────────────────────
+
+
+class TestTimeoutContract:
+    """Guard: _run()'s timeout-mock contract must stay intact."""
+
+    def test_run_returns_rc_124_and_timed_out_stderr_on_timeout(self):
+        cmd = ["python3", "-m", "pytest"]
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=cmd, timeout=600),
+        ):
+            result = vg._run(cmd, timeout=600)
+        assert result.returncode == 124
+        assert result.stderr == "python3: timed out after 600s"
+
+    @patch.object(vg, "_run")
+    def test_gate_fails_when_run_times_out(self, mock_run, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("")
+        mock_run.return_value = _mock_run(124, "", "python3: timed out after 600s")
+        result = vg.run_gate_unit(tmp_path)
+        assert result.status == "fail"
+        assert result.blocking is True
+
+
 # ── TestRunGateIntegration ───────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #55

## Root cause

`scripts/verify_gates.py` hard-coded `timeout=120` on both `run_gate_unit` call sites (pytest and npm branches). Any suite exceeding 120s made `_run()` map `subprocess.TimeoutExpired` to rc 124 + `timed out after 120s`, hard-failing the blocking unit gate during ship-smoke regardless of whether the tests would have passed.

## Fix

- Added `_DEFAULT_TEST_TIMEOUT = 600` and a local `_test_timeout()` helper in `verify_gates.py` that exactly mirrors `verify_checkpoint.py::_test_timeout`: reads `KIT_CHECKPOINT_TEST_TIMEOUT`, positive-int values override, unset / non-numeric / non-positive fall back to 600, resolved at call time. Cross-ref `# keep in sync` comments added in both files (the only change to `verify_checkpoint.py` is that one comment line).
- Both `run_gate_unit` call sites now use `timeout=_test_timeout()`. Nothing else changed; the `_run()` contract is untouched (TimeoutExpired still maps to rc 124 + `timed out after {N}s`, and an rc-124 result still yields gate status `fail`).

## Absorbed scope (flagged for reviewer veto)

`tests/test_verify_checkpoint.py::TestVerifyImplementTest::test_pass_when_pytest_succeeds` and `::test_fallback_when_pytest_cov_missing` patched only `vc._run` and mocked `git worktree list` with a slug-less tmp_path, so `_find_worktree_path` returned `None` and `verify_implement_test` fell back to `wt = Path.cwd()` (the real repo root). The unmocked `_run_verify_gates` then ran `run_applicable_gates(real_root)` in-process with the real `vg._run`, spawning a real recursive full-suite `python3 -m pytest -q --tb=short` that re-hits these same tests — making suite time ~21s base + 2 x unit-gate-timeout (unpassable for any timeout value) and orphaning a tree of recursive pytest processes.

Fix: these two tests now additionally patch `vc._run_verify_gates` with `return_value=True` and assert `mock_gates.assert_called_once()` so the isolation is a guard (TC-047g), not a silent mock. All pre-existing assertions unchanged; no other tests touched.

Absorption rationale (tech-lead approved): ISSUE-047's own Tests section requires "no real multi-minute pytest child runs anywhere in the suite", and the mandatory implement `test` checkpoint is unpassable without it. Precedent: ISSUE-046's accepted absorption.

## Premise correction

The "~5-minute suite" premise (and the live `GATE FAIL: unit (120.1s)` evidence) was an artifact of that test recursion — the true suite base time is ~21s. The env-configurable 600s default remains correct for robustness on genuinely long suites and for harness consistency with ISSUE-046's `verify_checkpoint.py` knob.

## Test evidence

- RED: 10 of the 12 new `tests/test_verify_gates.py` tests failed pre-fix (env override / 600 default / `"abc"`, `"0"`, `"-5"` fallback across pytest and npm branches; rc-124 timeout contract).
- GREEN (full suite, env unset): `1145 passed, 2 skipped, 1 warning in 10.70s`
- Mandatory `test` checkpoint: `PASS: tests passed` / `GATE PASS: unit [blocking] (14.2s)` / `GATE SKIP: load (0.0s)` (exit 0)
- Live gate under the 600s default: `env -u KIT_CHECKPOINT_TEST_TIMEOUT python3 scripts/verify_gates.py --project-path "$WT" --gates unit` → `PASS: unit [blocking] (13.7s)`, no `timed out after Ns`.

## Rollback

`git revert` of the two commits — changes are isolated to 4 files: `scripts/verify_gates.py`, `scripts/verify_checkpoint.py` (comment only), `tests/test_verify_gates.py`, `tests/test_verify_checkpoint.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)