### PR TITLE
[ISSUE-039] Harden security-guard hooks against malformed stdin

### DIFF
--- a/docs/.review/code-review.md
+++ b/docs/.review/code-review.md
@@ -1,86 +1,99 @@
-# Code Review (degraded) — ISSUE-038 / PR #59
+# Code Review — ISSUE-039 guard stdin hardening (PR #63)
 
-Scope: `git diff origin/main...HEAD` @ 1401f58 — `project/.claude/hooks/autotest.py` (+256/−81), `tests/test_autotest.py` (+206). Suite run in worktree: **31 passed in 2.69s** (no spawn-leak signal). Reviewed dimension: code (+ minimality folded in). Security reviewed separately.
-
-### [Medium] Non-atomic, lock-free cache writes: a stale "pass" can overwrite a fresh "fail" debounce entry under concurrent hook processes
-
-**Evidence:** `project/.claude/hooks/autotest.py:273-281` — `_save_cache` truncate-writes the whole file (`open(path, "w")` + `json.dump`), no temp-file/`os.replace`, no locking. `project/.claude/hooks/autotest.py:585-592` — the outcome is recorded with `"last_run": time.time()` taken *after* the runs complete (runs can take minutes: up to 5×30s unit + 2×60s E2E).
-
-**Impact:** Most race outcomes are fail-safe: a torn/interleaved write produces invalid JSON, which `_load_cache` rebuilds (re-run, never skip); a lost index entry just re-walks. But one interleaving is not: process A starts on source state S0 (tests pass), process B starts after an edit introduces a bug and records `"fail"`, then slow A finishes and overwrites the entry with `"pass"` and a fresh `last_run`. The next edit within 30s with unchanged test files is skipped — a failure debounced into silence, the exact AC-4 hazard. Requires two concurrent hook processes on the same file in the same project root (PostToolUse hooks serialize per agent, and kit worktrees have separate cache files, so this is narrow — hence Medium, not High).
-
-**Fix:** (1) Write atomically: dump to `path + ".tmp"` then `os.replace` (also eliminates the torn-write/rebuild churn). (2) Record `last_run` as the run *start* time, so the skip window is measured from when the tested state was captured. (3) When writing a `"pass"`, don't clobber an existing entry whose `last_run` is newer and whose result is `"fail"`.
-
-### [Medium] Index caches absolute test paths but the fingerprint is relpath-based — `mv`/clone of the project keeps a "valid" fingerprint pointing at the old tree
-
-**Evidence:** `project/.claude/hooks/autotest.py:304` — fingerprint entries use `os.path.relpath(entry.path, scan_root)`; `project/.claude/hooks/autotest.py:356-364` and `397-405` — the module index stores absolute `test_path` values; `project/.claude/hooks/autotest.py:575-576` — selected files are executed with no existence check.
-
-**Impact:** `mv project/ project2/` (or an APFS clonefile / `cp -c` / ns-preserving rsync copy) preserves mtimes exactly. The relocated cache's relpath fingerprint still matches, so the warm path returns the *old* absolute paths. If the old tree is gone: pytest runs a nonexistent path → nonzero exit → false `"Test failed"` block on every edit until a test file's mtime changes. If the old tree still exists (copy case): the hook silently runs the *original* tree's tests against stale code — a wrong-tree pass/fail with no signal. Workaround exists (delete `.claude/run/autotest_cache.json`), so Medium.
-
-**Fix:** Store module index entries as paths relative to `project_root` and join on read; or on a warm hit, verify each cached path with `os.path.isfile` and fall through to a rebuild if any is missing.
-
-### [Low] Fingerprint and discovery use mismatched predicates: hidden-dir JS tests and symlinked test files are discoverable but never invalidate the index
-
-**Evidence:** `project/.claude/hooks/autotest.py:234-238` — `_skip_js_scan_dir` excludes `node_modules` *and all hidden dirs* from the JS fingerprint; `project/.claude/hooks/autotest.py:389-393` — the discovery `os.walk` skips only `node_modules` (and doesn't prune `dirs`, so it still descends the node_modules tree — pre-existing). Also `project/.claude/hooks/autotest.py:301` — `entry.is_file(follow_symlinks=False)` excludes symlinked test files from the fingerprint, while `os.walk` + `open()` includes them in discovery (both Python and JS paths).
-
-**Impact:** A test file added/changed in a hidden dir (JS) or reached via symlink is invisible to the fingerprint: adding one never refreshes the index (AC-2 corner), and removing one leaves it cached. Rare layouts; degraded discovery only, debounce is unaffected (`_test_set_hash` stats the selected files directly). Low.
-
-**Fix:** Use the same predicate on both sides: prune the discovery walk with `_skip_js_scan_dir` (via `dirs[:] = [...]`, which also stops descending node_modules) and either include symlinked files in the fingerprint or exclude them from discovery.
-
-### [Low] Warm-path cache entries not validated to string paths — valid-JSON garbage can crash the hook, denting the fail-soft contract
-
-**Evidence:** `project/.claude/hooks/autotest.py:347-349` / `384-386` — `if isinstance(cached, list): return list(cached)` trusts element types. `_load_cache` (`:258-269`) validates the outer shape only. A hand-edited cache like `{"modules": {"user": [1]}}` passes validation; the int then reaches `subprocess.run([pytest_cmd, 1, ...])` → uncaught `TypeError` → traceback, exit 1.
-
-**Impact:** The stated contract is "corrupt cache → rebuild, never crash". Exit 1 is non-blocking in Claude Code (stderr noise, edit proceeds), and the trigger requires a hand-corrupted-but-valid-JSON cache, so no real exploit path — Low.
-
-**Fix:** Treat a cached value as a hit only if `all(isinstance(x, str) for x in cached)` (adding an `os.path.isfile` check here also mitigates the stale-abs-path finding above); otherwise fall through to rebuild.
-
-### [Low] `DEBOUNCE_SECONDS` is a new hard-coded time knob: no env override, no doc line
-
-**Evidence:** `project/.claude/hooks/autotest.py:20` — `DEBOUNCE_SECONDS = 30.0`. No mention in the module docstring, README, or `docs/troubleshooting.md` (grep confirms zero user-facing doc hits).
-
-**Impact:** Kit lesson (ISSUE-046/047): hard-coded timing constants introduced without env-configurability + docs recur as breakage. This one cannot break gates (it is not a subprocess timeout, and mis-sizing only delays or repeats *passing* runs — failures are exempt), so Low. Note: the diff introduces **no new subprocess `timeout=` literals**; the pre-existing 30s/60s caps remain the known logged planner candidate, out of this issue's scope.
-
-**Fix:** `DEBOUNCE_SECONDS = float(os.environ.get("AUTOTEST_DEBOUNCE_SECONDS", "30"))`, one line in the module docstring, one line in `docs/troubleshooting.md` (0 = disable).
-
-### [Low] Debounce map grows without pruning; full cache is rewritten on every event
-
-**Evidence:** `project/.claude/hooks/autotest.py:587-592` — `cache["debounce"][key] = {...}` keyed by absolute source path; entries for deleted/renamed files persist forever, and every event round-trips the entire JSON (both indexes + all debounce entries).
-
-**Impact:** Bounded by source-file count, so perf/bloat only. Low.
-
-**Fix:** On save, drop debounce entries with `last_run` older than a few windows (one-line dict comprehension).
-
-### [Low] Coverage gap: debounce window *expiry* is untested
-
-**Evidence:** `tests/test_autotest.py:571-595` asserts the within-window skip; no test asserts that an identical passing pair re-runs once `DEBOUNCE_SECONDS` elapses.
-
-**Impact:** A regression to an unbounded window (flipped comparison, wrong `last_run` type) would make the hook silently stop re-testing a passing module on later source edits — and no current test would fail. The main safety property (failures re-run) *is* tested, so Low.
-
-**Fix:** Monkeypatch `autotest.time.time` (or set `autotest.DEBOUNCE_SECONDS = 0.0`) and assert the second `handle_event` re-runs.
-
-### [Low] Corrupt-cache test cannot detect a late hook crash — `run_hook` discards returncode/stderr
-
-**Evidence:** `tests/test_autotest.py:11-21` — `run_hook` returns parsed stdout or `None`; `tests/test_autotest.py:542-547` (`test_corrupt_cache_rebuilds_and_exits_clean`) asserts `out is None` and that the cache file is valid JSON. A crash *after* `find_related_python_tests` saves the rebuilt cache (e.g. in the debounce block) produces empty stdout + traceback on stderr + exit 1 — and the test still passes. The "exits clean" claim in the name is not asserted.
-
-**Impact:** Hollow-assertion risk for exactly the fail-soft contract this test exists to pin. Low (the crash-on-load case *is* caught via the still-corrupt cache file).
-
-**Fix:** Have `run_hook` (or this test locally) surface `result.returncode`/`stderr` and assert `returncode == 0` and no traceback.
-
-## Over-Engineering (minimality axis)
-
-- tests/test_autotest.py:545-560: shrink — `_load` and `_make_python_project` duplicated verbatim between `TestIndexCache` and `TestDebounce` → hoist both to module-level helpers (or a fixture) shared by the two classes (~22 lines).
-- tests/test_autotest.py:449-452: delete — per-call `sys.path.insert` + `importlib.reload`; the module holds no mutable global state the tests reset, and repeated inserts accumulate in `sys.path` → single module-level import (folds into the shared helper above) (~4 lines).
-- Considered, rejected: the hand-rolled recursive `os.scandir` in `_stat_fingerprint` looks like an `os.walk` reinvention, but AC-1's letter (zero `os.walk` calls on the warm path, asserted by monkeypatch) mandates it — not a cut. `CACHE_VERSION` is cheap forward-compat for an on-disk format — not yagni.
-
-Net removable lines: ~25 (all test-side).
+Reviewer: degraded-path code reviewer (runtime `/code-review` not exposed).
+Diff range: `e87bc38..cde204d`. All 39 tests pass (`uv run pytest tests/test_secret_guard.py tests/test_dangerous_command_guard.py -q` → 39 passed, 0.69s).
 
 ## AC verification
 
-- **AC-1 (warm index, no walk): PASS.** Warm hit is `_load_cache` + stat-only scandir fingerprint + cached list; zero `os.walk` calls asserted for both Python and JS paths (TC-038a). Stat scan on the hot path is explicitly allowed by the spec's "tests-dir mtime scan" note.
-- **AC-2 (invalidation): PASS** (with the hidden-dir/symlink corner, Low). Any add/modify/delete of a fingerprint-visible test file changes `(relpath, mtime_ns, size)` → immediate reindex; TC-038b asserts discovery and on-disk persistence.
-- **AC-3 (debounce skip): PASS.** Same `(lang:abspath, test-set hash)` with `result == "pass"` inside 30s skips; TC-038c mocks the module-global runner seam with a call-count guard (correct seam per kit lesson).
-- **AC-4 (failure never debounced): PASS.** The skip path requires `result == "pass"`; TC-038d asserts a second block and an increased run count. Residual: the narrow cross-process pass-over-fail overwrite (Medium finding above).
+- **AC1 (malformed/empty stdin → exit 0, no traceback, stderr diagnostic): PASS.**
+  Verified by tests (garbage / empty / truncated JSON) and empirically: `null`,
+  `[1,2]`, `"str"`, `42`, `true`, invalid UTF-8 bytes (`\xff\xfe...`), and
+  C-locale (`LC_ALL=C`) all produce the diagnostic + rc 0 with no traceback.
+- **AC2 (valid Write secret payload blocks exactly as before, stderr clean): PASS.**
+  `tests/test_secret_guard.py:198` asserts block JSON on stdout and `stderr == ""`;
+  all 7 pre-existing detection tests unchanged and passing.
+- **AC3 (valid Bash dangerous payload blocks as before): PASS.**
+  `tests/test_dangerous_command_guard.py:158` plus 13 pre-existing blocking tests.
+- **RED honesty verified:** the base-commit hook (`git show e87bc38:...`) tracebacks
+  with rc=1 on garbage stdin, so the new tests genuinely failed before the fix and
+  would fail again if the try/except, the diagnostic, or the exit-0 behavior regressed.
+- **Recalled-lesson checks:** no new env-var knobs introduced (lesson 2 — n/a);
+  subprocess children are the tiny hook scripts themselves — no recursion, no pytest
+  spawn, no network, stdin fully written and closed by `subprocess.run(input=...)`,
+  so they always terminate (lesson 3 — clean); guards read only stdin (lesson 4 —
+  top-level gate in scope, field-level typing is GAP-039a, out of scope, boundary
+  re-confirmed empirically: `{"tool_name": "Write", "tool_input": null}` still
+  tracebacks, exactly as logged).
 
-Behavior knobs preserved: `MAX_RELATED_TESTS = 5` (autotest.py:197,555), `TIMEOUT = 30` / `E2E_TIMEOUT = 60` untouched, block-dict shape and unit-then-E2E ordering unchanged; caps are applied *before* the debounce hash so the debounce covers exactly what runs.
+## Findings
 
-Confidence: **High** — full diff + full file read, suite run green (2.69s), mock seams and tmp_path containment verified against recalled lessons, each finding actively falsification-checked (e.g. `mv` preserves mtime_ns, making the stale-abs-path fingerprint match real; all other write races degrade to safe re-runs).
+### 1. Low — Closed stdin fd still tracebacks (`sys.stdin` is `None`)
+
+- **File:** `project/.claude/hooks/secret_guard.py:54`, `project/.claude/hooks/dangerous_command_guard.py:44`
+- **Evidence:** `python3 secret_guard.py 0<&-` →
+  `AttributeError: 'NoneType' object has no attribute 'read'`, rc=1. When fd 0 is
+  closed at exec (not merely empty), CPython sets `sys.stdin = None`, so the
+  `.read()` call raises before `json.loads` and outside the caught exception types.
+- **Impact:** Not reachable under Claude Code's hook invocation (the runtime always
+  provides a stdin pipe, and the `|| true` wrappers in `hooks/hooks.json:62,71`
+  mask the nonzero exit), but it is the one remaining stdin-acquisition crash in
+  the hardened path. AC1's "empty stdin" (empty string) case is handled; this is
+  the adjacent "absent stdin" case.
+- **Fix:** `raw = sys.stdin.read() if sys.stdin is not None else ""` inside the
+  try, or add `AttributeError` / `OSError` to the except tuple. One line per guard.
+
+### 2. Low — UnicodeDecodeError coverage is load-bearing but implicit and untested
+
+- **File:** `project/.claude/hooks/secret_guard.py:55`, `project/.claude/hooks/dangerous_command_guard.py:45`; tests `tests/test_secret_guard.py:22`, `tests/test_dangerous_command_guard.py:22`
+- **Evidence:** `printf '\xff\xfe{"a":1}' | python3 secret_guard.py` → diagnostic,
+  rc 0 — works only because `UnicodeDecodeError` is a subclass of `ValueError`.
+  Nothing in the code says so, and no test exercises it: `run_hook_raw` uses
+  `text=True` so it physically cannot send undecodable bytes.
+- **Impact:** A future "cleanup" narrowing the except to `json.JSONDecodeError`
+  alone would reintroduce a traceback on undecodable stdin, and the suite would
+  stay green.
+- **Fix:** Append `# ValueError also covers UnicodeDecodeError (undecodable stdin)`
+  to the except line, and optionally add one bytes-mode test per file
+  (`subprocess.run([...], input=b"\xff\xfe", capture_output=True)` without
+  `text=True`) asserting rc 0 + diagnostic.
+
+### 3. Low — `run_hook_raw` / `run_hook` subprocess calls have no `timeout` (assessed per recalled lesson 1)
+
+- **File:** `tests/test_secret_guard.py:22-28`, `tests/test_dangerous_command_guard.py:22-28` (pre-existing `run_hook:9-19` likewise)
+- **Evidence:** `subprocess.run([sys.executable, str(SCRIPT)], input=raw_stdin, capture_output=True, text=True)` — no `timeout=`.
+- **Impact:** Assessed against the ISSUE-046/047 timeout lesson: this seam is NOT
+  the test-runner-spawning class that bit us. The child is a ~90-line script with
+  no network, no recursion, and stdin fully delivered and closed by
+  `subprocess.run(input=)`; hang risk is negligible and the 39-test suite runs in
+  0.69s. Flagged only for completeness; the sentinel-outcome concern does not apply.
+- **Fix (optional):** `timeout=10` on both helpers as cheap insurance against a
+  future hook edit that blocks on input.
+
+## Minimality (over-engineering axis)
+
+- `tests/test_secret_guard.py:9`: shrink — `run_hook`'s duplicated `subprocess.run` block → `out = run_hook_raw(json.dumps(payload)).stdout.strip(); return json.loads(out) if out else None` (~7 lines)
+- `tests/test_dangerous_command_guard.py:9`: shrink — same delegation of `run_hook` to `run_hook_raw` (~7 lines)
+
+Not flagged (deliberate, correct tradeoffs): the footgun comment block is duplicated
+across both guards, but the guards are standalone scripts run from
+`$CLAUDE_PLUGIN_ROOT` with no import path — a shared module would add a real seam
+to remove a comment; `except (json.JSONDecodeError, ValueError)` is technically
+redundant (subclass) but the breadth is load-bearing (finding 2) — do not narrow it.
+
+**Net removable lines: ~14.**
+
+## Self-Review
+
+- Severity re-assessment: all findings Low — none has a practical trigger under
+  real hook invocation; none blocks merge. No inflation, no suppression.
+- False-positive check: findings 1 and 2 verified by direct execution; finding 3
+  verified as a real absence and explicitly assessed as low-risk for this seam.
+- Blind spot scan: probed non-dict JSON, undecodable bytes, C locale, closed fd,
+  empty stdin, valid-path stderr cleanliness; re-read test assertions for honesty
+  (each asserts rc, stdout emptiness, diagnostic substrings, and no "Traceback").
+- AC verification: all 3 ACs pass (see above), RED→GREEN honesty confirmed against
+  the base commit.
+- Confidence: **High** — every claim in this review was verified empirically, not
+  by inspection alone.
+
+**Verdict: approve.** No blocking findings; the three Lows are follow-up polish.

--- a/docs/.review/findings.json
+++ b/docs/.review/findings.json
@@ -1,101 +1,46 @@
 {
-  "pr_number": "59",
+  "pr_number": "63",
   "code_source": "reviewer-degraded",
   "security_source": "reviewer-degraded",
   "code_findings": [
     {
-      "severity": "Medium",
-      "title": "Non-atomic, lock-free cache writes: a stale \"pass\" can overwrite a fresh \"fail\" debounce entry under concurrent hook processes",
-      "evidence": "project/.claude/hooks/autotest.py:273-281 _save_cache truncate-writes with open(path,'w')+json.dump (no temp+os.replace, no lock); :585-592 records last_run=time.time() AFTER runs complete (runs can take minutes). Interleaving: slow pass-run finishing after a newer fail-run overwrites result='fail' with 'pass' + fresh last_run; next edit within 30s with unchanged tests is skipped — AC-4 hazard. All other race outcomes (torn write, lost index entry) degrade safely to rebuild/re-run.",
-      "fix": "Write atomically (dump to path+'.tmp', os.replace); record last_run as run START time; when writing 'pass', do not clobber a newer entry whose result is 'fail'."
-    },
-    {
-      "severity": "Medium",
-      "title": "Index caches absolute test paths but fingerprint is relpath-based — mv/clone of the project keeps a matching fingerprint pointing at the old tree",
-      "evidence": "project/.claude/hooks/autotest.py:304 fingerprint uses os.path.relpath(entry.path, scan_root); :356-364 and :397-405 store absolute test_path in the module index; :575-576 run selected files with no existence check. mv (or mtime-preserving copy) keeps mtime_ns -> fingerprint matches -> warm path returns old absolute paths: false 'Test failed' block on missing files, or silently running the ORIGINAL tree's tests (copy case).",
-      "fix": "Store module index entries relative to project_root and join on read; or verify each cached path with os.path.isfile on a warm hit and fall through to rebuild if any is missing."
+      "severity": "Low",
+      "title": "Closed stdin fd still tracebacks (sys.stdin is None)",
+      "evidence": "project/.claude/hooks/secret_guard.py:54, project/.claude/hooks/dangerous_command_guard.py:44 — `python3 secret_guard.py 0<&-` raises `AttributeError: 'NoneType' object has no attribute 'read'`, rc=1. When fd 0 is closed at exec (not merely empty), CPython sets sys.stdin = None, so .read() raises before json.loads and outside the caught exception types. Not reachable under Claude Code's hook invocation (runtime always provides a stdin pipe; the `|| true` wrappers in hooks/hooks.json:62,71 mask the nonzero exit). AC1's empty-stdin case is handled; this is the adjacent absent-stdin case.",
+      "fix": "`raw = sys.stdin.read() if sys.stdin is not None else \"\"` inside the try, or add AttributeError / OSError to the except tuple. One line per guard."
     },
     {
       "severity": "Low",
-      "title": "Fingerprint vs discovery predicate mismatch: hidden-dir JS tests and symlinked test files are discoverable but never invalidate the index",
-      "evidence": "project/.claude/hooks/autotest.py:234-238 _skip_js_scan_dir excludes node_modules AND all hidden dirs from the JS fingerprint; :389-393 the discovery os.walk skips only node_modules (and never prunes dirs, still descending node_modules — pre-existing); :301 is_file(follow_symlinks=False) excludes symlinked test files from the fingerprint while os.walk+open includes them. Adding/changing such a test never refreshes the index (AC-2 corner).",
-      "fix": "Use one predicate on both sides: prune the discovery walk via dirs[:] filtering with _skip_js_scan_dir, and align symlink handling between fingerprint and discovery."
+      "title": "UnicodeDecodeError coverage is load-bearing but implicit and untested",
+      "evidence": "project/.claude/hooks/secret_guard.py:55, project/.claude/hooks/dangerous_command_guard.py:45 — `printf '\\xff\\xfe{\"a\":1}' | python3 secret_guard.py` yields the diagnostic with rc 0 only because UnicodeDecodeError subclasses ValueError. Nothing in the code says so, and no test exercises it: run_hook_raw uses text=True so it physically cannot send undecodable bytes. A future cleanup narrowing the except to json.JSONDecodeError alone would reintroduce a traceback on undecodable stdin and the suite would stay green.",
+      "fix": "Append `# ValueError also covers UnicodeDecodeError (undecodable stdin)` to the except line, and optionally add one bytes-mode test per file (subprocess.run without text=True, input=b\"\\xff\\xfe\") asserting rc 0 + diagnostic."
     },
     {
       "severity": "Low",
-      "title": "Warm-path cache entries not validated to string paths — valid-JSON garbage reaches subprocess.run and crashes the hook (fail-soft contract dent)",
-      "evidence": "project/.claude/hooks/autotest.py:347-349 and :384-386 'if isinstance(cached, list): return list(cached)' trusts element types; _load_cache (:258-269) validates outer shape only. A hand-edited cache with e.g. [1] passes validation, then subprocess.run([pytest_cmd, 1, ...]) raises uncaught TypeError -> traceback, exit 1 (non-blocking noise, no exploit path).",
-      "fix": "Accept a cached hit only if all(isinstance(x, str) for x in cached) (optionally + os.path.isfile, which also mitigates the stale-abs-path finding); otherwise rebuild."
+      "title": "run_hook_raw / run_hook subprocess calls have no timeout (assessed per recalled hard-coded-timeout lesson)",
+      "evidence": "tests/test_secret_guard.py:22-28, tests/test_dangerous_command_guard.py:22-28 (pre-existing run_hook:9-19 likewise) — subprocess.run([sys.executable, str(SCRIPT)], input=raw_stdin, capture_output=True, text=True) with no timeout=. Assessed against the ISSUE-046/047 timeout lesson: this seam is NOT the test-runner-spawning class that bit us. The child is a ~90-line script with no network, no recursion, and stdin fully delivered and closed by subprocess.run(input=); hang risk is negligible and the 39-test targeted run completes in 0.69s. Flagged only for completeness; the timeout-sentinel concern does not apply.",
+      "fix": "Optional: timeout=10 on both helpers as cheap insurance against a future hook edit that blocks on input."
     },
     {
       "severity": "Low",
-      "title": "DEBOUNCE_SECONDS is a new hard-coded time knob with no env override and no doc line",
-      "evidence": "project/.claude/hooks/autotest.py:20 'DEBOUNCE_SECONDS = 30.0'; zero mentions in module docstring, README, or docs/troubleshooting.md (grep-verified). Kit lesson ISSUE-046/047: undocumented, non-configurable timing constants recur as breakage. Cannot break gates (not a subprocess timeout; failures are exempt from debounce). Diff introduces no new subprocess timeout= literals.",
-      "fix": "DEBOUNCE_SECONDS = float(os.environ.get('AUTOTEST_DEBOUNCE_SECONDS', '30')) + one docstring line + one docs/troubleshooting.md line (0 = disable)."
-    },
-    {
-      "severity": "Low",
-      "title": "Debounce map grows without pruning; entire cache JSON rewritten every event",
-      "evidence": "project/.claude/hooks/autotest.py:587-592 cache['debounce'][key] keyed by absolute source path; entries for deleted/renamed files persist forever and every event round-trips the full JSON. Bounded by source-file count — perf/bloat only.",
-      "fix": "On save, drop debounce entries with last_run older than a few debounce windows (one-line dict comprehension)."
-    },
-    {
-      "severity": "Low",
-      "title": "Coverage gap: debounce window expiry is untested — an unbounded-window regression would silently stop re-testing passing modules",
-      "evidence": "tests/test_autotest.py:571-595 asserts the within-window skip only; no test asserts a re-run once DEBOUNCE_SECONDS elapses. A flipped comparison or wrong last_run type would pass every current test.",
-      "fix": "Monkeypatch autotest.time.time (or set autotest.DEBOUNCE_SECONDS = 0.0) and assert the second handle_event re-runs the tests."
-    },
-    {
-      "severity": "Low",
-      "title": "Corrupt-cache test cannot detect a late hook crash — run_hook discards returncode/stderr, making 'exits clean' unasserted",
-      "evidence": "tests/test_autotest.py:11-21 run_hook returns parsed stdout or None; tests/test_autotest.py:542-547 asserts out is None + rebuilt cache is valid JSON. A crash AFTER find_related_python_tests saves the rebuilt cache (e.g. in the debounce block) yields empty stdout + exit 1 and the test still passes. Crash-on-load IS caught (cache stays corrupt).",
-      "fix": "Surface result.returncode/stderr from run_hook (or locally in this test) and assert returncode == 0 with no traceback in stderr."
-    },
-    {
-      "severity": "Low",
-      "title": "[debt] KIT-DEBT ledger has 3 no-trigger markers (silent-rot risk) — all harvester self-references, none introduced by this PR",
-      "evidence": "checkpoint.sh --skill review --phase debt --issue ISSUE-038: total 14 markers, 3 no-trigger (scripts/debt_harvest.py:44 docstring format example; tests/test_debt_harvest.py:27 and :59 deliberate no-trigger test fixtures), 1 malformed (tests/test_debt_harvest.py:35 deliberate fixture). Identical state to the ISSUE-046/047 reviews' ledgers — pre-existing, not from PR #59's diff.",
-      "fix": "Pre-existing and self-referential (harvester's own docs/tests): consider teaching debt_harvest.py to exclude its own docstring examples and test fixture strings from the ledger so real no-trigger debt stands out."
+      "title": "[debt] Debt-ledger no-trigger markers are pre-existing harvester self-matches, none from this PR",
+      "evidence": "Advisory debt checkpoint: total 14 markers, 3 no-trigger (scripts/debt_harvest.py:44 docstring example line; tests/test_debt_harvest.py:27,59 test-fixture strings), 1 malformed (tests/test_debt_harvest.py:35 fixture). All are the harvester's own documentation/fixture text matching its own pattern — known false-positive class already recorded in the ISSUE-047 review. This diff introduces zero KIT-DEBT markers.",
+      "fix": "No action for this PR. Follow-up candidate: teach debt_harvest.py to skip its own source/tests or require the marker at comment position."
     }
   ],
-  "security_findings": [
-    {
-      "severity": "Medium",
-      "title": "Cache-derived related-test paths executed unvalidated on warm hits (cache poisoning -> out-of-tree file execution + pytest/vitest option injection)",
-      "evidence": "find_related_python_tests/find_related_js_tests return list(cached) with no re-validation (autotest.py:347-349, 384-386); _run_source_branch appends cached rf without the os.path.isfile guard primary gets (autotest.py:549-551) and passes it to subprocess argv in run_python_test ([pytest, tf, -x, ...], autotest.py:147-152). The stored fingerprint is itself in the writable cache, so a poisoned cache can match the current tree, skip the scan, and return arbitrary modules entries pointing outside tests/ or the project root, bypassing the test-name predicate, or starting with '-' (interpreted by pytest/vitest as options/plugins like -p/-c/--pdb).",
-      "fix": "Treat cached paths as untrusted on read: drop any entry that is not an existing regular file, not under project_root (py: project_root/tests), fails the _is_*_test_file predicate, or starts with '-'. Apply the os.path.isfile guard to rf that primary already gets."
-    },
-    {
-      "severity": "Low",
-      "title": "Debounce trusts an attacker-writable 'pass' entry to suppress the block-on-failure safety signal",
-      "evidence": "_run_source_branch returns None (tests skipped, no block) when a cached debounce entry has result=='pass', matching test_set, and last_run within DEBOUNCE_SECONDS (autotest.py:562-571). The fail-soft, workspace-writable cache lets a pre-seeded 'pass' entry (forged test_set is just a SHA-1 over unchanged test files' path/mtime/size) mute a genuine failing run for up to 30s after a source edit that breaks tests without touching test files. Bounded: advisory hook, 30s window, local-write precondition.",
-      "fix": "Document that autotest is not a security control; consider not letting a stored 'pass' suppress a run across separate hook invocations (in-memory debounce, or namespace/sign the cache) so on-disk tampering cannot mute a real failure."
-    },
-    {
-      "severity": "Low",
-      "title": "Non-atomic, symlink-following cache write can clobber a pre-planted symlink target",
-      "evidence": "_save_cache does os.makedirs(exist_ok=True) then open(path, 'w') with no O_NOFOLLOW and no atomic temp-then-rename (autotest.py:277-279). If .claude/run/autotest_cache.json or .claude/run/ is an attacker-planted symlink, the hook overwrites the target with cache JSON (destructive clobber, not injection). Non-atomic write can also corrupt the cache under concurrent hooks.",
-      "fix": "Write to a temp file in the same dir and os.replace() into place; refuse to follow a symlink at the final path (os.open with O_NOFOLLOW, or reject if os.path.islink(path))."
-    },
-    {
-      "severity": "Low",
-      "title": "Cache persists absolute paths (OS username / project layout) and is not covered by .gitignore",
-      "evidence": "python_index/js_index module lists and every debounce key store os.path.abspath(...) values like /Users/<user>/... (autotest.py:561, 356, 397). git check-ignore .claude/run/autotest_cache.json returns not-ignored (exit 1) and the repo .gitignore has no .claude/run/ entry, though docs/telemetry_schema.md asserts .claude/run/ is gitignored. No secrets/file-contents are stored, so impact is limited to leaking usernames and test structure if committed.",
-      "fix": "Add .claude/run/ to the kit's shipped/template .gitignore (and this repo's), and/or store project-relative paths in the cache."
-    }
-  ],
+  "security_findings": [],
   "minimality_findings": [
     {
       "severity": "Low",
-      "title": "[shrink] _load and _make_python_project duplicated verbatim between TestIndexCache and TestDebounce",
-      "evidence": "tests/test_autotest.py:545-560 duplicates tests/test_autotest.py:447-467 helper-for-helper.",
-      "fix": "Hoist both to module-level helpers (or a fixture) shared by the two classes (~22 lines removed)."
+      "title": "[shrink] run_hook can delegate to run_hook_raw in test_secret_guard.py",
+      "evidence": "tests/test_secret_guard.py:9 — run_hook's duplicated subprocess.run block.",
+      "fix": "out = run_hook_raw(json.dumps(payload)).stdout.strip(); return json.loads(out) if out else None (~7 lines removable)."
     },
     {
       "severity": "Low",
-      "title": "[delete] Per-call sys.path.insert + importlib.reload in test _load helpers",
-      "evidence": "tests/test_autotest.py:449-452 (and 547-550): the hook module holds no mutable global state the tests need reset, and repeated inserts accumulate in sys.path.",
-      "fix": "Single module-level import of autotest, folded into the shared helper above (~4 lines removed)."
+      "title": "[shrink] run_hook can delegate to run_hook_raw in test_dangerous_command_guard.py",
+      "evidence": "tests/test_dangerous_command_guard.py:9 — same duplicated subprocess.run block.",
+      "fix": "Same delegation of run_hook to run_hook_raw (~7 lines removable). Net removable across both files: ~14 lines. Deliberately NOT flagged: the duplicated footgun comment block (guards are standalone scripts with no import path) and the technically-redundant (JSONDecodeError, ValueError) tuple — its ValueError breadth is load-bearing per code finding 2; do not narrow it."
     }
   ],
   "ui_findings": null,

--- a/docs/.review/security-review.md
+++ b/docs/.review/security-review.md
@@ -1,160 +1,78 @@
-# Security Review (degraded) — ISSUE-038 / PR #59
+# Security Review — ISSUE-039 guard stdin hardening (PR #63)
 
-Runtime `/security-review` is not exposed; this is the degraded-path security pass.
-Scope: the security checklist only (injection, authn/z, secrets, input validation,
-deserialization, dependencies, XSS, misconfiguration). Code-quality and the
-minimality axis are covered by separate invocations.
+Reviewer: degraded-path security reviewer (runtime `/security-review` not exposed).
+Diff range: `e87bc38..cde204d`.
 
-Files reviewed:
-- `project/.claude/hooks/autotest.py` (+256/-81) — the PostToolUse hook now
-  persists a module→test-file index and a debounce state under
-  `.claude/run/autotest_cache.json`.
-- `tests/test_autotest.py` (+206).
+## No findings.
 
-Threat-model baseline (from the task): the hook *already* discovers and executes
-test files from the workspace by design, and can BLOCK the model's action on
-failure. Findings below are scoped to NEW attack surface introduced by the cache.
+No Critical/High/Medium/Low security findings in this diff. The fail-open change
+was audited against the checklist below; conclusions with evidence:
 
-## Surfaces explicitly checked and cleared
+### Fail-open decision and bypass analysis (the central question)
 
-- **Deserialization (pickle vs json).** Cache is read with `json.load` only
-  (`_load_cache`, line 255). No `pickle`/`eval`/`exec`/`yaml.load` anywhere in
-  the diff. `_load_cache` is strictly typed/validated and fail-soft
-  (`{{{ not json` → empty cache; test `test_corrupt_cache_rebuilds_and_exits_clean`).
-  Not a finding.
-- **Shell / command injection into argv.** All `subprocess.run` calls use list
-  form; no `shell=True`. Test file paths become discrete argv elements, so a
-  malicious *filename* cannot break out into a shell. (The one residual argv
-  concern — leading-dash option injection via a *poisoned* cache entry — is
-  folded into Finding 1.)
-- **Secrets / file contents.** The cache stores only file *paths*, `mtime_ns`,
-  `size`, and SHA-1 fingerprints. No file contents, tokens, or env values are
-  persisted. (Absolute-path/username leakage is Finding 4.)
-- **New env-var knobs / new subprocess-timeout instances.** None added.
-  `DEBOUNCE_SECONDS`/`CACHE_VERSION` are module constants, not env knobs; no new
-  `subprocess.run(timeout=...)` seam was introduced (the pre-existing 30s
-  `TIMEOUT` is out of scope per the task).
-- **Test code isolation.** Debounce tests monkeypatch at the correct seam
-  (`autotest.run_python_test`), so no recursive real-pytest spawn; other tests
-  run only trivial tempdir fixtures with test-controlled content. No unsafe
-  execution of untrusted input in the tests.
+**Threat model:** stdin to a PreToolUse hook is written exclusively by the Claude
+Code runtime, which serializes the hook payload itself. The adversarial party
+these guards defend against — a model turn attempting to write a secret or run a
+dangerous command (e.g. under prompt injection) — controls only the *values*
+inside `tool_input`, and the runtime JSON-escapes those values during
+serialization. There is no path by which attacker-influenced tool content can
+make the top-level payload undecodable or non-JSON, so **malformed stdin is not
+an attacker-reachable bypass**; it only occurs on runtime bugs or manual
+invocation. Given that, fail-open with a loud diagnostic is the correct posture:
+fail-closed would let a runtime serialization bug deny all Write/Edit/Bash use,
+and these guards are defense-in-depth behind the Claude Code permission system,
+not the primary boundary. This matches the issue spec's explicit design choice.
 
----
+### Checklist results
 
-### [Medium] Cache-derived related-test paths are executed unvalidated on warm hits (cache poisoning → out-of-tree file execution + pytest/vitest option injection)
+- **Injection/spoofing via diagnostics:** none. Both diagnostic strings
+  (`secret_guard.py:58`, `dangerous_command_guard.py:48`) are compile-time
+  constants with zero interpolation of payload data — no log-injection surface.
+- **Decision-channel integrity:** the diagnostic goes to stderr; stdout stays
+  JSON-or-nothing. Verified by tests asserting `stdout.strip() == ""` on the skip
+  path and `stderr == ""` on the block path, and empirically (rc 0, clean stdout)
+  for garbage / empty / non-dict / undecodable-bytes stdin.
+- **Guard regression on the block path:** none — valid secret and dangerous-command
+  payloads still emit the identical `{"decision": "block"}` stdout JSON (AC2/AC3
+  tests plus 20 pre-existing detection tests, all passing).
+- **Footgun comment accuracy:** verified against the real wrappers. Both
+  `hooks/hooks.json:62,71` and `project/.claude/settings.snippet.json:71,80` wrap
+  the guards in `bash -c '[ -f ... ] && python3 ... || true'`. The comment's
+  claims are correct: `|| true` is harmless while blocking is stdout-JSON with
+  exit 0, and would silently neutralize any future exit-code-2 conversion.
+- **Secrets in code/tests:** no new credentials. Test fixtures use the canonical
+  AWS documentation key (`AKIAIOSFODNN7EXAMPLE`) and synthetic tokens, in files
+  the secret guard's own SKIP_PATTERNS exempt — pre-existing pattern, unchanged.
+- **Dependencies / misconfiguration / XSS / authz:** no dependency, configuration,
+  or user-facing-output changes in the diff — n/a.
 
-**Evidence.** On a warm index hit, `find_related_python_tests` /
-`find_related_js_tests` return `list(cached)` verbatim with no re-validation
-(autotest.py:347-349, 384-386). `_run_source_branch` then appends every cached
-`rf` to `selected` **without** the `os.path.isfile` guard that `primary` gets:
+### Informational notes (not findings, no action required for merge)
 
-```python
-if primary and os.path.isfile(primary):     # primary IS checked
-    test_files.append(primary)
-for rf in related:                            # rf (from cache) is NOT checked
-    if rf not in test_files:
-        test_files.append(rf)
-...
-for tf in selected:
-    blocked = run_python_test(tf) if lang == "py" else run_js_test(tf)
-```
-`run_python_test` passes `tf` straight into `subprocess.run([pytest, tf, "-x", ...])`
-(autotest.py:147-152). Pytest *imports* the file it is pointed at, so an arbitrary
-path executes module-level code.
-
-The warm-hit path is fully attacker-steerable because the stored `fingerprint`
-is itself in the attacker-writable cache: the fingerprint is a SHA-1 of
-`(relpath, mtime_ns, size)` (`_stat_fingerprint`), all computable, so a poisoned
-cache can set `index["fingerprint"]` to match the *current* tree and thereby
-skip the scan entirely while returning arbitrary `modules` entries. Those entries
-can (a) point **outside** `tests/` and outside the project root (path traversal
-past what the scan would ever select), (b) skip the `test_`/`.test.` name
-predicate, and (c) begin with `-` (e.g. `"-pattacker_plugin"`, `"-c/tmp/evil.ini"`,
-`"--pdb"`), which pytest/vitest interpret as **options/plugins**, not paths.
-
-Precondition is local write to `.claude/run/autotest_cache.json`, which is
-roughly baseline-equivalent to dropping a `tests/test_x.py` — hence **Medium**,
-not High. The genuine escalation over baseline is: reaching files *outside* the
-workspace, bypassing the name filter, and injecting collector options/plugins.
-
-**Fix.** Treat cached paths as untrusted on read. In `_run_source_branch` (and/or
-at the point `list(cached)` is returned), drop any entry that is not an existing
-regular file, not under `project_root` (py: under `project_root/tests`), does not
-match the test-name predicate (`_is_python_test_file` / `_is_js_test_file`), or
-starts with `-`. Apply the same `os.path.isfile` guard to `rf` that `primary`
-already gets. This keeps warm-hit performance while making a poisoned cache no
-more powerful than the baseline scan.
-
-### [Low] Debounce trusts an attacker-writable "pass" entry to suppress the block-on-failure safety signal
-
-**Evidence.** `_run_source_branch` returns `None` (no block, tests skipped) when a
-cached debounce entry has `result == "pass"`, a matching `test_set`, and
-`last_run` within `DEBOUNCE_SECONDS` (autotest.py:562-571). The cache is
-fail-soft and writable anywhere in the workspace, so a pre-seeded `"pass"` entry
-— keyed on `lang:abspath(source)` with a forged matching `test_set` (again just
-`(path, mtime_ns, size)` SHA-1 over the unchanged test files) and a recent
-`last_run` — silences a genuine failing run for up to 30s after a source edit
-that breaks tests but doesn't touch the test files. Impact is bounded: this is
-the advisory autotest convenience hook, not an authoritative gate
-(`verify_gates.py`/CI are elsewhere), the window is 30s, and it needs local
-cache write.
-
-**Fix.** Acceptable within the stated threat model, but treat the debounce record
-as advisory-only: document that the autotest hook is not a security control, and
-consider not letting a *stored* `pass` suppress a run across separate hook
-invocations (e.g. keep debounce in memory for a single event, or namespace/sign
-the cache) so on-disk tampering cannot mute a real failure.
-
-### [Low] Non-atomic, symlink-following cache write can clobber a pre-planted symlink target
-
-**Evidence.** `_save_cache` does `os.makedirs(dirname, exist_ok=True)` then
-`open(path, "w")` with no `O_NOFOLLOW` and no atomic temp-then-rename
-(autotest.py:277-279). If `.claude/run/autotest_cache.json` (or `.claude/run/`)
-is a symlink an attacker planted in the workspace, the hook overwrites the link
-target with cache JSON. Content is attacker-uncontrolled JSON, so this is
-destructive (file clobber) rather than an injection vector, and requires the
-attacker to plant the link first. The non-atomic write can also corrupt the
-cache under concurrent hook invocations, though `_load_cache` fails soft on that.
-
-**Fix.** Write to a temp file in the same directory and `os.replace()` into place
-(atomic), and refuse to follow a symlink at the final path (e.g. `os.open` with
-`O_NOFOLLOW`, or reject if `os.path.islink(path)`).
-
-### [Low] Cache persists absolute paths (OS username / project layout) and is not covered by .gitignore
-
-**Evidence.** `python_index`/`js_index` module lists and every `debounce` key
-store `os.path.abspath(...)` values such as `/Users/<user>/...`
-(autotest.py:561, 356, 397). `git check-ignore .claude/run/autotest_cache.json`
-returns "not ignored" (exit 1), and the repo `.gitignore` has no `.claude/run/`
-entry — even though `docs/telemetry_schema.md` asserts `.claude/run/` is
-gitignored. If a consumer commits the cache it leaks local usernames and internal
-test structure. No secrets or file contents are exposed, so severity is Low.
-
-**Fix.** Add `.claude/run/` to the kit's shipped/template `.gitignore` (and this
-repo's), and/or store project-relative paths in the cache instead of absolute
-ones.
-
----
+1. **Diagnostic visibility is bounded by the runtime:** stderr from an exit-0
+   PreToolUse hook surfaces in transcript/verbose output, not as a prominent
+   warning. "Loud" is as loud as the runtime allows for exit 0; this is the
+   documented tradeoff the issue chose over exit-code-2, and the alternative is
+   explicitly out of scope.
+2. **Known residual crash surfaces, both fail-open with visible tracebacks and
+   masked exit codes by `|| true`:** closed stdin fd (code-review finding 1) and
+   wrong-typed dict fields (GAP-039a, out of scope, boundary re-confirmed:
+   `tool_input: null` still tracebacks). Neither is attacker-reachable for the
+   same threat-model reason as above.
+3. **Pre-existing, not in diff:** the `[ -f ... ] &&` wrapper means a
+   missing/renamed guard file silently disables the guard with no diagnostic at
+   all — a quieter fail-open than anything this PR touches. Worth a future issue
+   if guard-presence assurance ever matters.
 
 ## Self-Review
 
-1. **Severity re-assessment.** Finding 1 yields code execution but its precondition
-   (local write to the cache) is ~equivalent to the hook's existing baseline
-   capability, so it is capped at Medium; the delta over baseline (out-of-tree
-   files, name-filter bypass, option injection, scan bypass via forged fingerprint)
-   is real and justifies Medium over Low. Findings 2–4 are bounded, local-precondition,
-   non-injection issues → Low.
-2. **False-positive check.** Finding 1: code-traced — `rf` is appended without the
-   `os.path.isfile` guard `primary` gets, and reaches `subprocess` argv (confirmed
-   autotest.py:549-551, 575-576, 147-152). Finding 4: confirmed via `git check-ignore`
-   exit 1. Finding 3: confirmed `open(path,"w")` with no atomic/no-follow. Finding 2:
-   confirmed `result == "pass"` gate. No FPs identified.
-3. **Blind-spot scan.** Injection (argv list-form — safe; option-injection folded
-   into F1), deserialization (json only — cleared), secrets (no contents stored —
-   cleared), dependencies (none added), authn/z & XSS (n/a for a local FS hook) all
-   re-examined; nothing further surfaced.
-4. **AC note.** Security dimension only; the cache/debounce behave as designed
-   (fail-soft, failures never debounced), which the tests demonstrate.
-5. **Confidence: Medium-High.** The hook is small and fully read; the only real
-   judgment call is the Medium-vs-Low calibration on Finding 1, which I anchored to
-   the local-write precondition and the "new surface beyond baseline" rule.
+- Severity re-assessment: zero findings is the honest result — every candidate
+  either lacks an exploit path under the actual threat model (stdin author is the
+  trusted runtime) or re-litigates an explicit, documented spec decision.
+- False-positive/false-negative check: actively searched for a bypass (can guarded
+  content break the payload parse? No — runtime escapes it) and for diagnostic
+  injection (constant strings — none).
+- Blind spot scan: re-checked all seven checklist categories; only injection,
+  input-validation, and misconfiguration are touched by this diff, and each was
+  probed empirically.
+- Confidence: **High** — wrapper wiring, escape behavior, and all skip/block paths
+  verified by direct execution against both the head and base commits.

--- a/docs/review_notes/ISSUE-039.md
+++ b/docs/review_notes/ISSUE-039.md
@@ -1,0 +1,35 @@
+# Review Notes — PR #63
+
+## Code Review
+_Source: reviewer-degraded_
+
+- **[Low] Closed stdin fd still tracebacks (sys.stdin is None)**
+  Evidence: project/.claude/hooks/secret_guard.py:54, project/.claude/hooks/dangerous_command_guard.py:44 — `python3 secret_guard.py 0<&-` raises `AttributeError: 'NoneType' object has no attribute 'read'`, rc=1. When fd 0 is closed at exec (not merely empty), CPython sets sys.stdin = None, so .read() raises before json.loads and outside the caught exception types. Not reachable under Claude Code's hook invocation (runtime always provides a stdin pipe; the `|| true` wrappers in hooks/hooks.json:62,71 mask the nonzero exit). AC1's empty-stdin case is handled; this is the adjacent absent-stdin case.
+  Fix: `raw = sys.stdin.read() if sys.stdin is not None else ""` inside the try, or add AttributeError / OSError to the except tuple. One line per guard.
+
+- **[Low] UnicodeDecodeError coverage is load-bearing but implicit and untested**
+  Evidence: project/.claude/hooks/secret_guard.py:55, project/.claude/hooks/dangerous_command_guard.py:45 — `printf '\xff\xfe{"a":1}' | python3 secret_guard.py` yields the diagnostic with rc 0 only because UnicodeDecodeError subclasses ValueError. Nothing in the code says so, and no test exercises it: run_hook_raw uses text=True so it physically cannot send undecodable bytes. A future cleanup narrowing the except to json.JSONDecodeError alone would reintroduce a traceback on undecodable stdin and the suite would stay green.
+  Fix: Append `# ValueError also covers UnicodeDecodeError (undecodable stdin)` to the except line, and optionally add one bytes-mode test per file (subprocess.run without text=True, input=b"\xff\xfe") asserting rc 0 + diagnostic.
+
+- **[Low] run_hook_raw / run_hook subprocess calls have no timeout (assessed per recalled hard-coded-timeout lesson)**
+  Evidence: tests/test_secret_guard.py:22-28, tests/test_dangerous_command_guard.py:22-28 (pre-existing run_hook:9-19 likewise) — subprocess.run([sys.executable, str(SCRIPT)], input=raw_stdin, capture_output=True, text=True) with no timeout=. Assessed against the ISSUE-046/047 timeout lesson: this seam is NOT the test-runner-spawning class that bit us. The child is a ~90-line script with no network, no recursion, and stdin fully delivered and closed by subprocess.run(input=); hang risk is negligible and the 39-test targeted run completes in 0.69s. Flagged only for completeness; the timeout-sentinel concern does not apply.
+  Fix: Optional: timeout=10 on both helpers as cheap insurance against a future hook edit that blocks on input.
+
+- **[Low] [debt] Debt-ledger no-trigger markers are pre-existing harvester self-matches, none from this PR**
+  Evidence: Advisory debt checkpoint: total 14 markers, 3 no-trigger (scripts/debt_harvest.py:44 docstring example line; tests/test_debt_harvest.py:27,59 test-fixture strings), 1 malformed (tests/test_debt_harvest.py:35 fixture). All are the harvester's own documentation/fixture text matching its own pattern — known false-positive class already recorded in the ISSUE-047 review. This diff introduces zero KIT-DEBT markers.
+  Fix: No action for this PR. Follow-up candidate: teach debt_harvest.py to skip its own source/tests or require the marker at comment position.
+
+## Security Findings
+_Source: reviewer-degraded_
+
+_No findings._
+
+## Over-Engineering
+
+- **[Low] [shrink] run_hook can delegate to run_hook_raw in test_secret_guard.py**
+  Evidence: tests/test_secret_guard.py:9 — run_hook's duplicated subprocess.run block.
+  Fix: out = run_hook_raw(json.dumps(payload)).stdout.strip(); return json.loads(out) if out else None (~7 lines removable).
+
+- **[Low] [shrink] run_hook can delegate to run_hook_raw in test_dangerous_command_guard.py**
+  Evidence: tests/test_dangerous_command_guard.py:9 — same duplicated subprocess.run block.
+  Fix: Same delegation of run_hook to run_hook_raw (~7 lines removable). Net removable across both files: ~14 lines. Deliberately NOT flagged: the duplicated footgun comment block (guards are standalone scripts with no import path) and the technically-redundant (JSONDecodeError, ValueError) tuple — its ValueError breadth is load-bearing per code finding 2; do not narrow it.

--- a/project/.claude/hooks/dangerous_command_guard.py
+++ b/project/.claude/hooks/dangerous_command_guard.py
@@ -31,8 +31,23 @@ def check_command(command: str) -> tuple[bool, str]:
     return False, ""
 
 
+# Blocking mechanism (footgun warning):
+# - This guard blocks via stdout JSON {"decision": "block"} with exit code 0 —
+#   NOT via exit code. stdout is the decision channel: JSON-or-nothing.
+# - Therefore a shell `|| true` wrapper around this hook is harmless today.
+# - BUT: if anyone converts this guard to exit-code-2 blocking, any `|| true`
+#   wrapper would silently neutralize the guard — remove such wrappers first.
+# - Parse failures fail OPEN (guard skipped) with a loud stderr diagnostic and
+#   exit 0, honoring the hooks-never-crash-a-session contract.
 def main():
-    hook_input = json.loads(sys.stdin.read())
+    try:
+        hook_input = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        hook_input = None
+    if not isinstance(hook_input, dict):
+        print("dangerous_command_guard: malformed hook payload — guard skipped", file=sys.stderr)
+        return
+
     tool_name = hook_input.get("tool_name", "")
 
     if tool_name != "Bash":

--- a/project/.claude/hooks/secret_guard.py
+++ b/project/.claude/hooks/secret_guard.py
@@ -41,8 +41,23 @@ def scan_content(content: str) -> list[str]:
     return findings
 
 
+# Blocking mechanism (footgun warning):
+# - This guard blocks via stdout JSON {"decision": "block"} with exit code 0 —
+#   NOT via exit code. stdout is the decision channel: JSON-or-nothing.
+# - Therefore a shell `|| true` wrapper around this hook is harmless today.
+# - BUT: if anyone converts this guard to exit-code-2 blocking, any `|| true`
+#   wrapper would silently neutralize the guard — remove such wrappers first.
+# - Parse failures fail OPEN (guard skipped) with a loud stderr diagnostic and
+#   exit 0, honoring the hooks-never-crash-a-session contract.
 def main():
-    hook_input = json.loads(sys.stdin.read())
+    try:
+        hook_input = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        hook_input = None
+    if not isinstance(hook_input, dict):
+        print("secret_guard: malformed hook payload — guard skipped", file=sys.stderr)
+        return
+
     tool_name = hook_input.get("tool_name", "")
 
     if tool_name not in ("Write", "Edit"):

--- a/tests/test_dangerous_command_guard.py
+++ b/tests/test_dangerous_command_guard.py
@@ -19,6 +19,15 @@ def run_hook(payload: dict) -> dict | None:
     return None
 
 
+def run_hook_raw(raw_stdin: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input=raw_stdin,
+        capture_output=True,
+        text=True,
+    )
+
+
 def make_bash_payload(command: str) -> dict:
     return {
         "tool_name": "Bash",
@@ -123,3 +132,32 @@ class TestNonBashTool:
         }
         out = run_hook(payload)
         assert out is None
+
+
+class TestMalformedStdin:
+    def assert_guard_skipped(self, result: subprocess.CompletedProcess):
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+        assert "dangerous_command_guard" in result.stderr
+        assert "malformed hook payload" in result.stderr
+        assert "guard skipped" in result.stderr
+        assert "Traceback" not in result.stderr
+
+    def test_garbage_stdin_skips_guard_without_traceback(self):
+        result = run_hook_raw("not-json")
+        self.assert_guard_skipped(result)
+
+    def test_empty_stdin_skips_guard_without_traceback(self):
+        result = run_hook_raw("")
+        self.assert_guard_skipped(result)
+
+    def test_truncated_json_skips_guard_without_traceback(self):
+        result = run_hook_raw('{"tool_name": "Write", "tool_input": {')
+        self.assert_guard_skipped(result)
+
+    def test_valid_blocking_payload_keeps_stderr_clean(self):
+        result = run_hook_raw(json.dumps(make_bash_payload("rm -rf /")))
+        assert result.returncode == 0
+        out = json.loads(result.stdout)
+        assert out["decision"] == "block"
+        assert result.stderr == ""

--- a/tests/test_secret_guard.py
+++ b/tests/test_secret_guard.py
@@ -19,6 +19,15 @@ def run_hook(payload: dict) -> dict | None:
     return None
 
 
+def run_hook_raw(raw_stdin: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input=raw_stdin,
+        capture_output=True,
+        text=True,
+    )
+
+
 class TestSecretDetection:
     def test_blocks_aws_key(self):
         payload = {
@@ -163,3 +172,39 @@ class TestNonTargetTools:
         }
         out = run_hook(payload)
         assert out is None
+
+
+class TestMalformedStdin:
+    def assert_guard_skipped(self, result: subprocess.CompletedProcess):
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+        assert "secret_guard" in result.stderr
+        assert "malformed hook payload" in result.stderr
+        assert "guard skipped" in result.stderr
+        assert "Traceback" not in result.stderr
+
+    def test_garbage_stdin_skips_guard_without_traceback(self):
+        result = run_hook_raw("not-json")
+        self.assert_guard_skipped(result)
+
+    def test_empty_stdin_skips_guard_without_traceback(self):
+        result = run_hook_raw("")
+        self.assert_guard_skipped(result)
+
+    def test_truncated_json_skips_guard_without_traceback(self):
+        result = run_hook_raw('{"tool_name": "Write", "tool_input": {')
+        self.assert_guard_skipped(result)
+
+    def test_valid_blocking_payload_keeps_stderr_clean(self):
+        payload = {
+            "tool_name": "Write",
+            "tool_input": {
+                "file_path": "/tmp/config.py",
+                "content": 'AWS_KEY = "AKIAIOSFODNN7EXAMPLE"',
+            },
+        }
+        result = run_hook_raw(json.dumps(payload))
+        assert result.returncode == 0
+        out = json.loads(result.stdout)
+        assert out["decision"] == "block"
+        assert result.stderr == ""


### PR DESCRIPTION
Closes #60

## Summary
`secret_guard.py` and `dangerous_command_guard.py` parsed hook stdin with a bare `json.loads(sys.stdin.read())` — any malformed payload raised an unhandled traceback and the guard was silently skipped (fail-open with no signal). This hardens both guards:

- Stdin parse wrapped in `try/except (json.JSONDecodeError, ValueError)`; a single `isinstance(hook_input, dict)` gate also covers valid-JSON-but-non-dict payloads (`[1,2,3]`, `42`).
- On parse failure: one-line stderr diagnostic (`<guard>: malformed hook payload — guard skipped`) and exit 0 — fail-open stays, but it is now loud, honoring the hooks-never-crash-a-session contract.
- stdout stays a pure decision channel (JSON-or-nothing); blocking semantics untouched.
- In-file comment block in both hooks documenting the footgun: blocking happens via stdout JSON `{"decision": "block"}` with exit 0, so `|| true` wrappers are harmless today — but converting to exit-code-2 blocking would be silently neutralized by such wrappers.

Explicitly NOT done (out of scope): changing detection patterns, changing blocking semantics, converting to exit-code-2.

## Tests (TDD)
RED commit e5d5666 adds 8 subprocess tests (garbage `not-json`, empty stdin, truncated JSON per guard → rc 0, empty stdout, stderr skip diagnostic, no traceback; plus valid-blocking-payload stderr-purity regression guards), verified genuinely failing against the unmodified hooks. GREEN commit cde204d makes them pass.

- Targeted: 39 passed (`tests/test_secret_guard.py`, `tests/test_dangerous_command_guard.py`)
- Full suite: 1169 passed, 2 skipped (baseline 1161 + 8 new)

## Rollback
`git revert` — two small hook files, no state.