### PR TITLE
[ISSUE-048] Scope implement checkpoints to the branch's own delta (merge-base diff)

### DIFF
--- a/docs/review_notes/ISSUE-048.md
+++ b/docs/review_notes/ISSUE-048.md
@@ -1,0 +1,21 @@
+# Review Notes — PR #77
+
+## Code Review
+_Source: reviewer-degraded_
+
+- **[Low] Fallback test exercises only half the empty/detached guard**
+  Evidence: tests/test_checkpoint_merge_base.py::test_merge_base_falls_back_when_unresolvable monkeypatches vc._merge_base to None and only asserts isinstance(result,set); it never drives _merge_base to genuinely return None in a real orphan/unrelated-history repo, nor asserts the branch's own file resolves through the base fallback.
+  Fix: Add a git checkout --orphan (or unrelated-history) fixture where `git merge-base HEAD main` really returns empty; assert vc._merge_base(...) is None and the branch file still resolves. Reviewer confirmed the fallback works out-of-band.
+
+- **[Low] _existing() 'files' parameter is untyped, breaking the module's annotation convention**
+  Evidence: scripts/verify_checkpoint.py _existing(wt_path: str, files) -> set[str] — surrounding helpers are fully typed.
+  Fix: Annotate files: Iterable[str] (from collections.abc import Iterable).
+
+## Security Findings
+_Source: reviewer-degraded_
+
+_No findings._
+
+## Over-Engineering
+
+_No findings._

--- a/scripts/verify_checkpoint.py
+++ b/scripts/verify_checkpoint.py
@@ -436,17 +436,35 @@ def verify_implement_worktree(issue_id: str, **_) -> bool:
     return True
 
 
-def verify_implement_code(issue_id: str, **_) -> bool:
-    """Worktree has non-docs file changes (committed or uncommitted)."""
-    wt_path = _find_worktree_path(issue_id)
-    if not wt_path:
-        print(f"FAIL: no worktree found for {issue_id}")
-        return False
+def _merge_base(wt_path: str, base: str) -> str | None:
+    """Return the fork point (``git merge-base HEAD <base>``), or None.
 
-    base = _default_branch()
+    None signals an unresolvable base (unborn/detached HEAD, no common
+    ancestor, or a mocked environment) so callers can fall back to diffing
+    against <base> directly rather than crashing.
+    """
+    result = _run(["git", "merge-base", "HEAD", base], cwd=wt_path)
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+    return None
 
-    # Committed changes vs default branch
-    diff_committed = _run(["git", "diff", "--name-only", base], cwd=wt_path)
+
+def _changed_files_vs_base(wt_path: str, base: str) -> set[str]:
+    """Files the branch itself changed, diffed against its merge-base with <base>.
+
+    Diffing against the fork point (``git merge-base HEAD <base>``) instead of
+    <base> directly means a worktree built on a STALE <base> does not surface
+    files that <base> added or deleted after the fork point — only the branch's
+    own delta is reported (ISSUE-048). Falls back to diffing <base> directly
+    when the fork point cannot be determined, preserving the previous behavior
+    rather than crashing.
+
+    Returns committed + staged + unstaged + untracked paths as a set.
+    """
+    diff_base = _merge_base(wt_path, base) or base
+
+    # Committed changes vs the branch's fork point (its own delta only)
+    diff_committed = _run(["git", "diff", "--name-only", diff_base], cwd=wt_path)
     # Staged but not yet committed
     diff_staged = _run(["git", "diff", "--name-only", "--cached"], cwd=wt_path)
     # Unstaged modifications
@@ -460,6 +478,30 @@ def verify_implement_code(issue_id: str, **_) -> bool:
     for r in (diff_committed, diff_staged, diff_unstaged, untracked):
         if r.returncode == 0 and r.stdout.strip():
             all_files.update(r.stdout.strip().splitlines())
+    return all_files
+
+
+def _existing(wt_path: str, files) -> set[str]:
+    """Restrict a changed-file set to paths that exist in the worktree tree.
+
+    Belt-and-suspenders against stale-base / rename-as-delete phantoms
+    (ISSUE-048): a path that <base> added after the fork point (absent from
+    HEAD's tree) or a path renamed away must not be classified (e.g. mis-flagged
+    as a hollow test just because it can't be read).
+    """
+    wt = Path(wt_path)
+    return {f for f in files if f and (wt / f).exists()}
+
+
+def verify_implement_code(issue_id: str, **_) -> bool:
+    """Worktree has non-docs file changes (committed or uncommitted)."""
+    wt_path = _find_worktree_path(issue_id)
+    if not wt_path:
+        print(f"FAIL: no worktree found for {issue_id}")
+        return False
+
+    base = _default_branch()
+    all_files = _changed_files_vs_base(wt_path, base)
 
     changed = [f for f in all_files if f and not f.startswith("docs/")]
     if not changed:
@@ -582,19 +624,11 @@ def verify_implement_red(issue_id: str, **_) -> bool:
 
     wt = Path(wt_path)
 
-    # First, verify test files exist and have real assertions
+    # First, verify test files exist and have real assertions. Scope to the
+    # branch's own delta (merge-base diff) and keep only files that exist in the
+    # worktree, so a stale base can't inject a phantom test path (ISSUE-048).
     base = _default_branch()
-    diff_committed = _run(["git", "diff", "--name-only", base], cwd=wt_path)
-    diff_staged = _run(["git", "diff", "--name-only", "--cached"], cwd=wt_path)
-    diff_unstaged = _run(["git", "diff", "--name-only"], cwd=wt_path)
-    untracked = _run(
-        ["git", "ls-files", "--others", "--exclude-standard"], cwd=wt_path
-    )
-
-    all_files: set[str] = set()
-    for r in (diff_committed, diff_staged, diff_unstaged, untracked):
-        if r.returncode == 0 and r.stdout.strip():
-            all_files.update(r.stdout.strip().splitlines())
+    all_files = _existing(wt_path, _changed_files_vs_base(wt_path, base))
 
     test_pattern = re.compile(
         r"(?:^|/)(?:test_[^/]+\.py|[^/]+_test\.py|[^/]+\.(?:spec|test)\.(?:ts|tsx|js|jsx))$"
@@ -670,21 +704,10 @@ def verify_implement_tests_written(issue_id: str, **_) -> bool:
 
     base = _default_branch()
 
-    # Committed changes vs default branch
-    diff_committed = _run(["git", "diff", "--name-only", base], cwd=wt_path)
-    # Staged but not yet committed
-    diff_staged = _run(["git", "diff", "--name-only", "--cached"], cwd=wt_path)
-    # Unstaged modifications
-    diff_unstaged = _run(["git", "diff", "--name-only"], cwd=wt_path)
-    # Untracked files
-    untracked = _run(
-        ["git", "ls-files", "--others", "--exclude-standard"], cwd=wt_path
-    )
-
-    all_files: set[str] = set()
-    for r in (diff_committed, diff_staged, diff_unstaged, untracked):
-        if r.returncode == 0 and r.stdout.strip():
-            all_files.update(r.stdout.strip().splitlines())
+    # Scope to the branch's own delta (merge-base diff) and keep only files that
+    # actually exist in the worktree, so a stale base can't inject a phantom test
+    # path that then fails the hollow-test check (ISSUE-048).
+    all_files = _existing(wt_path, _changed_files_vs_base(wt_path, base))
 
     # Match test files: test_*.py, *_test.py, *.spec.ts, *.test.ts, etc.
     test_pattern = re.compile(

--- a/tests/test_checkpoint_merge_base.py
+++ b/tests/test_checkpoint_merge_base.py
@@ -1,0 +1,137 @@
+"""ISSUE-048: implement checkpoints scope to the branch's own delta (merge-base).
+
+A worktree built on a stale main must not surface files that main added or
+deleted after the fork point. Diffing against ``git merge-base HEAD main``
+(instead of ``main`` directly), plus intersecting with files that exist in the
+worktree tree, keeps the classified set to the branch's own delta so no
+phantom hollow-test FAIL is manufactured for a normal source+test change.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import verify_checkpoint as vc
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture()
+def stale_base_repo(tmp_path):
+    """Real git repo where main advances past the branch's fork point.
+
+    Timeline:
+      A (main)   -- fork point; branch 'feature' is cut here
+      B (main)   -- main adds tests/test_mainonly.py, which 'feature' never has
+      feature    -- adds arith.py + tests/test_arith.py (its own delta)
+
+    Diffing 'feature' against main (=B) would surface tests/test_mainonly.py as
+    a phantom path absent from the worktree tree; diffing against merge-base
+    (=A) must not.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "symbolic-ref", "HEAD", "refs/heads/main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Tester")
+    (repo / "pyproject.toml").write_text("[tool.pytest.ini_options]\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "A: fork point")
+
+    # Cut the branch at the fork point A.
+    _git(repo, "branch", "feature")
+
+    # main advances to B, adding a test file the branch will never have.
+    tests = repo / "tests"
+    tests.mkdir()
+    (tests / "test_mainonly.py").write_text(
+        "def test_main_only():\n    assert True\n", encoding="utf-8"
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "B: main-only test added after fork")
+
+    # Switch to the branch (still at A) and add its own source + test delta.
+    _git(repo, "checkout", "feature")
+    (repo / "arith.py").write_text(
+        "def total(a, b):\n    return a + b\n", encoding="utf-8"
+    )
+    (repo / "tests").mkdir(exist_ok=True)
+    (repo / "tests" / "test_arith.py").write_text(
+        "from arith import total\n\n"
+        "def test_total_regression():\n"
+        "    assert total(1, 2) == 3\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "feature: arithmetic source + test")
+    return repo
+
+
+class TestMergeBaseHelpers:
+    def test_changed_files_vs_base_excludes_post_fork_main_files(self, stale_base_repo):
+        # merge-base diff scopes to the branch's own delta; the main-only file
+        # added on main after the fork point is NOT reported for this branch.
+        changed = vc._changed_files_vs_base(str(stale_base_repo), "main")
+        assert "tests/test_arith.py" in changed
+        assert "arith.py" in changed
+        assert "tests/test_mainonly.py" not in changed
+
+    def test_existing_intersection_drops_absent_paths(self, stale_base_repo):
+        # Belt-and-suspenders: a path absent from the worktree tree is dropped
+        # before classification even if a raw diff had surfaced it.
+        classified = vc._existing(
+            str(stale_base_repo),
+            {"tests/test_arith.py", "tests/test_mainonly.py"},
+        )
+        assert "tests/test_arith.py" in classified
+        assert "tests/test_mainonly.py" not in classified
+
+    def test_merge_base_falls_back_when_unresolvable(self, tmp_path, monkeypatch):
+        # Empty/detached merge-base -> fall back to <base> rather than crashing.
+        monkeypatch.setattr(vc, "_merge_base", lambda wt, base: None)
+        repo = tmp_path / "r"
+        repo.mkdir()
+        _git(repo, "init")
+        _git(repo, "symbolic-ref", "HEAD", "refs/heads/main")
+        _git(repo, "config", "user.email", "t@e")
+        _git(repo, "config", "user.name", "T")
+        (repo / "a.py").write_text("x = 1\n", encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "init")
+        # Must return a set without raising even when merge-base is None.
+        result = vc._changed_files_vs_base(str(repo), "main")
+        assert isinstance(result, set)
+
+
+class TestTestsWrittenScopedToBranchDelta:
+    @pytest.fixture()
+    def _synthetic_issue(self, stale_base_repo, monkeypatch):
+        monkeypatch.setattr(vc, "_find_worktree_path", lambda issue_id: str(stale_base_repo))
+        monkeypatch.setattr(vc, "_default_branch", lambda: "main")
+        monkeypatch.setattr(vc, "_repo_root", lambda: stale_base_repo)
+        # Non-UI issue block, no AC checkboxes -> AC-coverage check is a no-op.
+        (stale_base_repo / "issues.md").write_text(
+            "### ISSUE-001: Add arithmetic total\n- Status: doing\n", encoding="utf-8"
+        )
+        return stale_base_repo
+
+    def test_stale_base_branch_passes_without_phantom_hollow_fail(self, _synthetic_issue):
+        # The whole point: a stale-base branch's tests-written checkpoint passes
+        # on its own real test; the phantom main-only file never triggers a
+        # hollow-test FAIL because it is scoped out by the merge-base diff.
+        assert vc.verify_implement_tests_written("ISSUE-001") is True
+
+    def test_no_regression_branch_delta_test_still_detected(self, _synthetic_issue):
+        # No-regression AC: the branch's own added source+test is still detected
+        # exactly as before.
+        changed = vc._changed_files_vs_base(str(_synthetic_issue), "main")
+        assert "tests/test_arith.py" in changed
+        assert vc.verify_implement_tests_written("ISSUE-001") is True


### PR DESCRIPTION
Closes #74

Implement-phase checkpoints (`verify_implement_tests_written`, `verify_implement_red`, `verify_implement_code`) diffed the worktree against `main` directly. A worktree built on a stale `main` therefore surfaced files that `main` added or deleted after the branch's fork point — those appear in `git diff --name-only main` but are absent from the worktree tree, so `_has_real_tests` returned False and produced a phantom hollow-test FAIL (ISSUE-041/044 both hit this and worked around it by fast-forwarding).

## Change
- New helpers `_merge_base`, `_changed_files_vs_base`, `_existing`.
- The three implement verifiers now diff against `git merge-base HEAD main` (the branch's own delta) and intersect the classified set with files that exist in the worktree.
- Falls back to diffing `main` directly when the fork point is unresolvable (unborn/detached HEAD).

## Tests
- New `tests/test_checkpoint_merge_base.py`: a real-git fixture where `main` advances past the branch's fork point (adding a main-only test the branch never has) — asserts the phantom file is absent from the classified set and the checkpoint passes on the branch's own real test.
- Existing `verify_checkpoint` tests pass unchanged (148 passed).
