### PR TITLE
[ISSUE-049] Gate the Figma visual-diff browser auto-install behind an explicit opt-in

### DIFF
--- a/docs/review_notes/ISSUE-049.md
+++ b/docs/review_notes/ISSUE-049.md
@@ -1,0 +1,21 @@
+# Review Notes — PR #78
+
+## Code Review
+_Source: reviewer-degraded_
+
+- **[Low] New env-var knob KIT_ALLOW_BROWSER_INSTALL is not documented in a user-facing doc**
+  Evidence: scripts/verify_visual_diff.py / verify_computed_styles.py introduce the knob; it appears only in docstrings + the runtime stderr hint. grep of README.md/docs returns nothing.
+  Fix: Add a one-line entry to docs/troubleshooting.md (and/or README) documenting KIT_ALLOW_BROWSER_INSTALL=1 and that unset = the visual-diff/computed-style gates skip cleanly. Matches the recalled env-knob-documentation lesson (ISSUE-046/047 precedent — recorded there as an open Low). Recorded here + logged as a sprint Discovered follow-up; deferred off-branch to avoid a merge conflict with the in-flight main-side troubleshooting/README edits.
+
+- **[Low] Unset-flag test pins the stderr diagnostic but not that stdout stays empty**
+  Evidence: tests/test_figma_verify_family.py test_flag_unset_and_missing_does_not_install asserts 'browser unavailable' in err but never asserts stdout=='' — the issue note explicitly requires stdout stays machine-clean.
+  Fix: Assert capsys.readouterr().out == '' on the unset path (capture out+err in one readouterr()).
+
+## Security Findings
+_Source: reviewer-degraded_
+
+_No findings._
+
+## Over-Engineering
+
+_No findings._

--- a/scripts/verify_computed_styles.py
+++ b/scripts/verify_computed_styles.py
@@ -21,24 +21,51 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
 
-def _check_playwright() -> bool:
+def _playwright_importable() -> bool:
+    """True iff `playwright.sync_api` imports (lazy — never at module load)."""
     try:
         from playwright.sync_api import sync_playwright  # noqa: F401
         return True
     except ImportError:
-        import subprocess
-        try:
-            subprocess.run(["pip", "install", "playwright"], capture_output=True, timeout=60)
-            subprocess.run(["playwright", "install", "chromium"], capture_output=True, timeout=120)
-            from playwright.sync_api import sync_playwright  # noqa: F401
-            return True
-        except Exception:
-            return False
+        return False
+
+
+def _check_playwright() -> bool:
+    """Report whether Playwright is available; auto-install only on opt-in.
+
+    A review/CI gate must never mutate its environment or reach the network as a
+    silent side effect (ISSUE-049). When Playwright is missing, the heavy
+    `pip install playwright` + `playwright install chromium` provisioning runs
+    ONLY when the operator sets ``KIT_ALLOW_BROWSER_INSTALL=1``. Otherwise the
+    gate reports "browser unavailable" to stderr and returns False so the caller
+    takes its existing skip/degrade path. The diagnostic goes to stderr; stdout
+    stays clean for machine-readable output.
+    """
+    if _playwright_importable():
+        return True
+
+    if os.environ.get("KIT_ALLOW_BROWSER_INSTALL") != "1":
+        print(
+            "browser unavailable — skipping computed-style verification "
+            "(set KIT_ALLOW_BROWSER_INSTALL=1 to auto-install Playwright + Chromium)",
+            file=sys.stderr,
+        )
+        return False
+
+    # Opted in: heavy provisioning (network + subprocess) is expected here.
+    try:
+        subprocess.run(["pip", "install", "playwright"], capture_output=True, timeout=60)
+        subprocess.run(["playwright", "install", "chromium"], capture_output=True, timeout=120)
+    except Exception:
+        return False
+    return _playwright_importable()
 
 
 # ── Build Figma token reference ─────────────────────────────────────

--- a/scripts/verify_visual_diff.py
+++ b/scripts/verify_visual_diff.py
@@ -18,6 +18,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 
@@ -44,23 +47,44 @@ _STABILIZE_CSS = """
 """
 
 
-def _check_playwright() -> bool:
-    """Check if Playwright is available and install if possible."""
+def _playwright_importable() -> bool:
+    """True iff `playwright.sync_api` imports (lazy — never at module load)."""
     try:
         from playwright.sync_api import sync_playwright  # noqa: F401
         return True
     except ImportError:
-        pass
+        return False
 
-    # Try auto-install
-    import subprocess
+
+def _check_playwright() -> bool:
+    """Report whether Playwright is available; auto-install only on opt-in.
+
+    A review/CI gate must never mutate its environment or reach the network as a
+    silent side effect (ISSUE-049). When Playwright is missing, the heavy
+    `pip install playwright` + `playwright install chromium` provisioning runs
+    ONLY when the operator sets ``KIT_ALLOW_BROWSER_INSTALL=1``. Otherwise the
+    gate reports "browser unavailable" to stderr and returns False so the caller
+    takes its existing skip/degrade path. The diagnostic goes to stderr; stdout
+    stays clean for machine-readable output.
+    """
+    if _playwright_importable():
+        return True
+
+    if os.environ.get("KIT_ALLOW_BROWSER_INSTALL") != "1":
+        print(
+            "browser unavailable — skipping visual diff "
+            "(set KIT_ALLOW_BROWSER_INSTALL=1 to auto-install Playwright + Chromium)",
+            file=sys.stderr,
+        )
+        return False
+
+    # Opted in: heavy provisioning (network + subprocess) is expected here.
     try:
         subprocess.run(["pip", "install", "playwright"], capture_output=True, timeout=60)
         subprocess.run(["playwright", "install", "chromium"], capture_output=True, timeout=120)
-        from playwright.sync_api import sync_playwright  # noqa: F401
-        return True
     except Exception:
         return False
+    return _playwright_importable()
 
 
 # ── Anti-aliasing aware pixel diff ──────────────────────────────────

--- a/tests/test_figma_verify_family.py
+++ b/tests/test_figma_verify_family.py
@@ -604,3 +604,61 @@ class TestGenerateCssMain:
 
     def test_main_missing_design_data_returns_one(self, tmp_path):
         assert gfc.main(["--project-path", str(tmp_path)]) == 1
+
+
+# ════════════════════════════════════════════════════════════════════
+# Browser auto-install is gated behind an explicit opt-in (ISSUE-049)
+# ════════════════════════════════════════════════════════════════════
+#
+# The visual-diff family must NEVER `pip install playwright` /
+# `playwright install chromium` (network + env mutation) as a silent side
+# effect. The heavy provisioning path runs only when KIT_ALLOW_BROWSER_INSTALL=1
+# is set; otherwise the gate reports "browser unavailable" to stderr and returns
+# False so the caller takes its existing skip/degrade path. The subprocess
+# boundary is mocked here — the suite never actually installs anything.
+
+
+@pytest.mark.parametrize("mod", [vvd, vcs], ids=["visual_diff", "computed_styles"])
+class TestBrowserInstallOptIn:
+    def test_flag_unset_and_missing_does_not_install(self, mod, monkeypatch, capsys):
+        # Opt-in flag unset + Playwright missing → NO install subprocess, no
+        # network; report unavailable and return False (skip/degrade path).
+        monkeypatch.delenv("KIT_ALLOW_BROWSER_INSTALL", raising=False)
+        monkeypatch.setattr(mod, "_playwright_importable", lambda: False)
+        calls = []
+        monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: calls.append(a))
+
+        assert mod._check_playwright() is False
+        assert calls == [], "install subprocess must NOT be spawned when opt-in is unset"
+        err = capsys.readouterr().err
+        assert "browser unavailable" in err.lower()
+
+    def test_flag_set_and_missing_runs_install_once(self, mod, monkeypatch):
+        # Opt-in flag set + Playwright missing → auto-install path runs as today
+        # (pip install playwright + playwright install chromium), each once.
+        monkeypatch.setenv("KIT_ALLOW_BROWSER_INSTALL", "1")
+        monkeypatch.setattr(mod, "_playwright_importable", lambda: False)
+        commands = []
+
+        def _spy(cmd, *a, **k):
+            commands.append(cmd)
+            return None
+
+        monkeypatch.setattr(mod.subprocess, "run", _spy)
+
+        mod._check_playwright()  # return value depends on post-install import
+        assert ["pip", "install", "playwright"] in commands
+        assert ["playwright", "install", "chromium"] in commands
+        assert len(commands) == 2, "install path should issue exactly the two install commands"
+
+    def test_present_playwright_never_installs_regardless_of_flag(self, mod, monkeypatch):
+        # Playwright present → True and no install, whether the flag is set or not.
+        monkeypatch.setattr(mod, "_playwright_importable", lambda: True)
+        calls = []
+        monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: calls.append(a))
+
+        monkeypatch.delenv("KIT_ALLOW_BROWSER_INSTALL", raising=False)
+        assert mod._check_playwright() is True
+        monkeypatch.setenv("KIT_ALLOW_BROWSER_INSTALL", "1")
+        assert mod._check_playwright() is True
+        assert calls == [], "present Playwright must never trigger an install"


### PR DESCRIPTION
Closes #75

`_check_playwright()` in `scripts/verify_visual_diff.py` and `scripts/verify_computed_styles.py` shelled out to `pip install playwright` + `playwright install chromium` (~180s, network) on any import-failure path — a review/CI gate silently mutating its environment and reaching the network.

## Change
- Extract `_playwright_importable()` (lazy import, never at module load — the no-browser-at-collection guarantee is preserved).
- `_check_playwright()` runs the heavy `pip`/`playwright install` provisioning ONLY when `KIT_ALLOW_BROWSER_INSTALL=1`. Unset → prints "browser unavailable" to stderr and returns False so the caller takes its existing skip/degrade path. Diagnostic to stderr keeps stdout machine-clean.

## Tests (subprocess boundary mocked — nothing is ever installed)
- flag unset + missing → install NOT spawned, skip taken, diagnostic on stderr
- flag set + missing → both install commands issued exactly once
- Playwright present → True, no install, regardless of flag
- existing no-browser-at-collection / import guard tests still pass
