### PR TITLE
[ISSUE-052] Make sprint_queue crash-recovery aware of already-merged PRs

### DIFF
--- a/agents/team-lead.md
+++ b/agents/team-lead.md
@@ -8,10 +8,11 @@ Role: You are a tech lead executing a specific sprint phase. The sprint orchestr
 
 ## Quick Summary
 
-Your job: execute a phase (PIPELINE, IMPLEMENT, REVIEW, or SHIP) for a batch of issues, then STOP. Specifics:
+Your job: execute a phase (PIPELINE, IMPLEMENT, REVIEW, SHIP, or FINALIZE) for a batch of issues, then STOP. Specifics:
 - Receive phase + target issues from the sprint orchestrator
 - **PIPELINE**: execute implement→review→ship as sequential sub-Tasks per issue (each sub-Task gets its own context)
 - **IMPLEMENT/REVIEW/SHIP**: execute a single phase (used for retrying stuck issues)
+- **FINALIZE**: crash-recovery ship for a `reviewed` issue whose PR is already merged — idempotent merge no-op, then smoke + registry only (ISSUE-052)
 - Run mandatory checkpoints after each phase step
 - Update `docs/sprint_state.md` with results (success, failure, findings)
 - Delegate all issues.md changes to planner agent
@@ -98,6 +99,19 @@ For each target issue:
       - Log the testgen invocation in `docs/sprint_state.md` > Discovered Issues.
    e) If no gaps found, skip silently.
 
+### When Phase = FINALIZE
+
+Crash-recovery only (ISSUE-052): the queue detected a `reviewed` issue whose PR is **already merged** — a ship-phase interruption between the squash-merge and the post-merge smoke checkpoint left `sprint_state` at `reviewed`/`shipping` while the PR is MERGED and the GH issue CLOSED. Only smoke + registry remain; a re-merge must NEVER be attempted.
+
+For each target issue:
+1. Read `skills/ship/SKILL.md` and follow its algorithm, but treat the merge step as a no-op: run `python3 scripts/sprint_queue.py ship-merge-decision --pr <pr_number>` and confirm it returns `{"action": "skip", ...}`. Do NOT run `gh pr merge`.
+2. Run the remaining ship checkpoints — cleanup, then the **BLOCKING** post-merge smoke checkpoint on main — exactly as in SHIP.
+3. Complete registry finalization (issues.md Status=done + backlog [x], CHANGELOG) via `registry_edit.sh`, then the post-ship test-gap check (same as SHIP step 5).
+4. On success: update Phase to `shipped` in sprint_state.md.
+5. On failure: log error, increment Attempts. If Attempts ≥ 2, escalate to human.
+
+If `ship-merge-decision` unexpectedly returns `merge` (the PR is NOT actually merged — stale classification), fall back to the normal **SHIP** handler: perform the merge, then continue. The idempotent guard makes this safe either way.
+
 ### After ANY phase completes
 
 1. **Update sprint_state.md**: Write current progress for all target issues.
@@ -159,7 +173,7 @@ All issues.md modifications go through planner + flock_edit.sh. Team-lead NEVER 
   - Never re-run a phase that already succeeded.
 - **Manual issue handling**: If a target issue has `Manual: true`, skip it and report back. (Sprint orchestrator should not dispatch manual issues, but guard against it.)
 - **Worktree cleanup**: Clean up worktrees for each issue after the phase completes (success or failure). Run: `bash scripts/wt_cleanup.sh <branch>`. If cleanup fails, log a warning but do not block. On PIPELINE failure (e.g., IMPLEMENT fails before SHIP), still clean up the worktree before returning.
-- **Scope discipline**: For IMPLEMENT/REVIEW/SHIP, execute ONLY the requested phase. For PIPELINE, execute all three phases in order via sub-Tasks — but do NOT loop or restart phases.
+- **Scope discipline**: For IMPLEMENT/REVIEW/SHIP/FINALIZE, execute ONLY the requested phase. For PIPELINE, execute all three phases in order via sub-Tasks — but do NOT loop or restart phases.
 - **Sub-Task context**: When dispatching sub-Tasks, pass only the issue spec and phase instruction. The sub-Task's skill re-reads all project docs (architecture.md, review lessons (native memory), etc.) from the file system — do NOT duplicate docs in the sub-Task prompt.
 
 ## Sprint State File (docs/sprint_state.md)

--- a/docs/review_notes/ISSUE-052.md
+++ b/docs/review_notes/ISSUE-052.md
@@ -1,0 +1,92 @@
+# Review Notes — ISSUE-052 (PR #83): sprint_queue crash-recovery aware of already-merged PRs
+
+Reviewer: degraded-path reviewer agent (runtime `/code-review` + `/security-review` not invocable from sub-agents; 048/049/050 precedent). Dimensions covered here: correctness, security, over-engineering minimality.
+
+Verdict: **REQUEST-CHANGES** (1 High wiring gap; 1 Medium robustness nit; Lows record-only).
+
+Tests: `pytest tests/test_sprint_queue.py` → 73 passed. All AC1/AC2/AC3 paths are covered at the script level and mocks are injected at the correct delegation seams (`runner`, `merge_state_fn`, module-global `_gh_pr_merge_state`); the argv is fixture-pinned (`test_argv_is_fixed_and_shell_free`).
+
+---
+
+## Code Review (correctness + minimality)
+
+### [High] `FINALIZE` is emitted by `next-action` but no consumer routes it — end-to-end recovery is not deterministic
+- Evidence: `scripts/sprint_queue.py:394-403` emits `action="FINALIZE"`, but the sole consumer of the `action` field — the sprint orchestrator — only routes `DONE | STUCK | PIPELINE | SHIP | REVIEW`:
+  - `skills/sprint/SKILL.md:138-140` (and `skills/sprint/SKILL.md.tmpl:77-79`): "If action = **PIPELINE**, **SHIP**, or **REVIEW** → proceed to step 4d". `FINALIZE` is not listed.
+  - `skills/sprint/SKILL.md:154` team-lead prompt hardcodes `## Phase: {PIPELINE | SHIP | REVIEW}` — `FINALIZE` is not an allowed phase value.
+  - This PR updated `skills/ship/SKILL.md` (idempotent merge) but did NOT update `skills/sprint/SKILL.md`, which is where the decision to invoke ship lives.
+- Impact: When the recovery scenario fires (reviewed issue, PR already merged), `next-action` correctly returns `FINALIZE` (AC1 satisfied at the script boundary) but the documented loop has no branch for it, so behavior is undefined — the kit's own rule is "do NOT override the script's action choice." Worse, the finalize-target issue is still at phase `reviewed`, so the step-5 completion gate (`skills/sprint/SKILL.md:193-197`, counts `implemented`/`reviewed`) re-enters step 4, `next-action` re-emits `FINALIZE`, and the loop can spin to `max-iterations` without ever finalizing. The issue Goal ("recovery is deterministic") is not met end-to-end.
+- Fix: Route `FINALIZE` in step 4b-c — treat it like `SHIP` (dispatch to the team-lead **ship** phase, which now idempotently skips the merge via `ship-merge-decision` and proceeds to smoke + registry) — and add `FINALIZE` to the team-lead phase enum at step 4d. The script side is already consistent (`ACTION_END_PHASE["FINALIZE"]="shipped"`, `validate --action FINALIZE` accepted), so this is a small, safe skill-text change. Regenerate `skills/sprint/SKILL.md` from the `.tmpl`.
+- Not tied to a recalled review lesson — this is an AC-verification / end-to-end-wiring catch.
+
+### [Medium] `_gh_pr_merge_state` crashes on valid-but-non-object JSON — contradicts its "never raises" contract and AC3
+- Evidence: `scripts/sprint_queue.py:248-258`. `json.loads` is wrapped in `try/except (ValueError, TypeError)`, but the subsequent `data.get("state")` / `data.get("mergedAt")` (lines 257-258) run OUTSIDE the `try`. Confirmed empirically: a runner returning returncode 0 with stdout `null`, `[]`, `123`, or `"x"` raises `AttributeError: '<type>' object has no attribute 'get'`, which propagates through `classify_ship_ready` (no try) → `cmd_next_action` and crashes the queue.
+- Impact: The docstring promises "Degrades to None — never raises — on ... unparseable JSON" and AC3 requires "never crashing the queue." A JSON scalar/array is parseable-but-not-an-object and slips past the guard. Trigger is unlikely with real `gh pr view --json state,mergedAt` (returncode 0 always yields an object), so this is a hard-to-reach edge, not a hot-path failure — hence Medium, not High.
+- Fix: guard the shape, e.g. `if not isinstance(data, dict): return None` right after the `json.loads` block, or move the two `.get` reads inside the existing `try`. Add a test for the non-object-JSON path.
+
+### [Low] `--no-check-merged` flag has no real caller — `yagni`
+- Evidence: `scripts/sprint_queue.py:652-660`. The flag is exercised only by `tests/test_sprint_queue.py::TestCLIFinalize::test_no_check_merged_flag_skips_probe`; no skill (`skills/sprint/SKILL.md`) passes it. The offline / `gh`-missing case already degrades correctly without it (probe returns `None` → issue stays `ship_ready`), and a missing `gh` fails fast (`FileNotFoundError`), not on the 10s timeout — so the flag's marginal value (skipping a hung-network probe in deterministic/CI runs) is narrow.
+- Minimality tag: `yagni` — `scripts/sprint_queue.py:652-660` `--no-check-merged` (+ the `getattr(args, "no_check_merged", ...)` guard at :574) → rely on graceful degradation, or wire the flag into a real caller. Defensible as a CI/offline escape hatch; record-only, not a blocker.
+
+### [Low] Test coverage gaps around the probe timeout / degradation edges
+- Evidence: `tests/test_sprint_queue.py` `TestGhPrMergeState` covers OSError, non-zero exit, and unparseable-JSON degradation, but not: (a) that the configured timeout (`GH_MERGE_PROBE_TIMEOUT` / `KIT_SPRINT_QUEUE_GH_TIMEOUT`) is actually passed to the runner's `timeout=` kwarg (the argv-pin test ignores kwargs), (b) that a `subprocess.TimeoutExpired` degrades to `None` (covered by the except clause but never asserted), (c) the non-object-JSON crash (finding above).
+- Fix: add assertions for the `timeout=` kwarg and a `TimeoutExpired` case. Record-only.
+
+### Minimality summary
+- `FINALIZE` action, `_gh_pr_merge_state`, `classify_ship_ready` (with per-ref cache), `ship_merge_decision` + `ship-merge-decision` subcommand: all justified — the subcommand has a real single consumer (`skills/ship/SKILL.md` step 4) and centralizes merged-detection + degradation. Not over-built.
+- Timeout knob is a latency/offline guard on a quick idempotent read that degrades to a safe phase-only decision — this is OUTSIDE the ISSUE-046/047 "hard-coded timeout that kills legitimately-long work" class (it kills nothing and loses no work), and it is env-overridable. Not flagged.
+- Net removable lines: ~10-12 (the `--no-check-merged` flag + its guard), only if the escape hatch is deemed unnecessary. Otherwise: lean.
+
+---
+
+## Security Findings
+
+_No findings._
+
+Notes (not findings): The `gh` probe uses a fixed argv list with no `shell=True` (`scripts/sprint_queue.py:227-233`); `pr_ref` is interpolated as a single argv element, so a PR ref containing shell metacharacters cannot inject — worst case `gh` errors and the probe degrades to `None`. The `pr_ref` originates from the repo-controlled `issues.md` `- PR:` field. Stderr echoed in the warnings (`proc.stderr.strip()`, line 244) comes from `gh`, which does not emit auth tokens in its error text, so no credential-leak path. No hardcoded secrets introduced.
+
+---
+
+## Self-Review
+- Severity re-assessment: High for the FINALIZE routing gap is justified — it defeats the issue's core "deterministic recovery" Goal and can non-terminate the sprint loop; the fix is small but load-bearing. Medium for the non-object-JSON crash is calibrated down from High because real `gh` cannot trigger it (returncode 0 ⇒ object). Env-knob doc + `--no-check-merged` are correctly Low.
+- False-positive check: FINALIZE gap is not excused by the change-surface list — `skills/sprint/SKILL.md` is the only `action` consumer and was left unrouted; verified there is no catch-all/unknown-action branch. The JSON crash is reproduced empirically, not hypothesized.
+- Blind-spot scan: injection (safe — fixed argv), backward compat (`choose_action` uses `queues.get("finalize_ready")`; existing tests with no `finalize_ready` key pass — `TestChooseActionFinalize::test_ship_when_no_finalize_key_present` pins this), idempotency default (`merge` on indeterminate is safe — the only way to `skip` is a definitive `merged`, and a stale-classification `gh pr merge` on an already-merged PR errors rather than double-merging; the merge checkpoint re-verifies).
+- AC verification: AC1 (finalize-only, not SHIP, no re-merge) — satisfied at the script boundary, but NOT actionable end-to-end (see High). AC2 (un-merged → SHIP) — satisfied and tested. AC3 (gh unavailable → graceful, logged, no crash) — satisfied for all real failure modes; the only residual crash is the unlikely non-object-JSON edge (Medium). Ship-executor idempotency — wired into `skills/ship/SKILL.md`.
+- Confidence: High.
+
+## Recalled-lesson trace
+- Env-var-knob documentation (ISSUE-046/047/038; ISSUE-049 precedent): `KIT_SPRINT_QUEUE_GH_TIMEOUT` is documented only in code comments/docstring, not in a user-facing doc or `--help`. Recorded as Low below.
+- Hard-coded subprocess timeout class (ISSUE-046/047): probe timeout is OUTSIDE the boundary (guards a quick read, degrades safely, env-overridable) — no finding.
+- Mock isolation at the delegation seam + fixture-pin (ISSUE-047/037): tests satisfy this (injected `runner`/`merge_state_fn`, monkeypatched module global, pinned argv) — no finding.
+
+### [Low] `KIT_SPRINT_QUEUE_GH_TIMEOUT` not documented in a user-facing surface
+- Evidence: `scripts/sprint_queue.py:51-58` documents the knob in comments/docstring only. It is absent from `docs/troubleshooting.md`, `README.md`, and the `next-action --help` text (which does surface `--no-check-merged`).
+- Fix: add a one-line entry to `docs/troubleshooting.md` (and/or `README.md`) — same remediation recorded for `KIT_ALLOW_BROWSER_INSTALL` in `docs/review_notes/ISSUE-049.md`. Record-only.
+
+---
+
+## Resolution (fixes applied on-branch, tests-first)
+
+- **[High] FINALIZE routing gap — FIXED.** Wired FINALIZE through the orchestrator:
+  `skills/sprint/SKILL.md.tmpl` step 4b-c now routes FINALIZE (proceed to 4d), the 4d
+  phase enum is `{PIPELINE | SHIP | REVIEW | FINALIZE}`, the priority note reads
+  `FINALIZE > SHIP > REVIEW > PIPELINE`, and a phase-meaning explains FINALIZE routes to
+  the team-lead ship executor with an idempotent (skip) merge + validate `--action FINALIZE`.
+  `agents/team-lead.md` gains a "When Phase = FINALIZE" handler (idempotent merge no-op via
+  `ship-merge-decision`, then smoke + registry; falls back to SHIP if the guard returns
+  `merge`). Regenerated `skills/sprint/SKILL.md`; freshness gate passes. Recovery is now
+  deterministic end-to-end and cannot spin the completion-gate loop.
+- **[Medium] non-object JSON crash — FIXED.** `_gh_pr_merge_state` now returns `None` (with a
+  warning) when `gh` yields valid-but-non-object JSON (`null`/`[]`/scalar) via an
+  `isinstance(data, dict)` guard, so the probe never raises (AC3). Added regression tests:
+  non-object JSON, timeout pass-through, and `TimeoutExpired` degradation.
+- **[Low] Missing tests — ADDRESSED** (non-object JSON + timeout pass-through + TimeoutExpired).
+- **[Low] `--no-check-merged` yagni — KEPT** as a deliberate offline/deterministic CI escape hatch
+  (tested); net cost is small.
+- **[Low] `KIT_SPRINT_QUEUE_GH_TIMEOUT` not in user-facing docs — DEFERRED** to a Discovered-Issue
+  doc follow-up (env-knob-documentation lesson), consistent with the ISSUE-049
+  `KIT_ALLOW_BROWSER_INSTALL` precedent — deferred off-branch to avoid conflicting with main's
+  in-flight uncommitted `docs/troubleshooting.md`/README edits. Knob remains documented in the
+  module (docstring + constant comment).
+
+Full suite after fixes: 1340 passed, 4 skipped.

--- a/scripts/sprint_queue.py
+++ b/scripts/sprint_queue.py
@@ -254,6 +254,15 @@ def _gh_pr_merge_state(pr_ref, *, timeout=None, runner=None):
             file=sys.stderr,
         )
         return None
+    if not isinstance(data, dict):
+        # Valid JSON that is not an object (null / list / scalar) — treat as
+        # indeterminate rather than raising, so AC3's "never crashes" holds.
+        print(
+            f"Warning: `gh pr view` JSON for {pr_ref} was not an object; "
+            "falling back to phase-only decision",
+            file=sys.stderr,
+        )
+        return None
     state = str(data.get("state") or "").upper()
     if state == "MERGED" or data.get("mergedAt"):
         return "merged"

--- a/scripts/sprint_queue.py
+++ b/scripts/sprint_queue.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -41,7 +43,19 @@ ACTION_END_PHASE: dict[str, str] = {
     "IMPLEMENT": "implemented",
     "REVIEW": "reviewed",
     "SHIP": "shipped",
+    # FINALIZE (ISSUE-052): a reviewed issue whose PR was already merged before a
+    # ship-phase crash — only smoke + registry remain, which still ends at shipped.
+    "FINALIZE": "shipped",
 }
+
+# ISSUE-052 crash-recovery: timeout (seconds) for the optional `gh pr view` merge
+# probe. The queue runs frequently, so an offline/hung `gh` must never block it —
+# on timeout the probe degrades to a phase-only decision. Overridable and
+# documented via the env knob below (env-knob-documentation review lesson).
+#   KIT_SPRINT_QUEUE_GH_TIMEOUT — seconds for the merge-state probe (default 10)
+GH_MERGE_PROBE_TIMEOUT: float = float(
+    os.environ.get("KIT_SPRINT_QUEUE_GH_TIMEOUT", "10")
+)
 
 # Phases that count as "in-flight" (actively being worked on)
 IN_FLIGHT_PHASES = {"implementing", "reviewing", "shipping"}
@@ -133,12 +147,15 @@ def parse_issues_metadata(text: str) -> dict[str, dict]:
         depends_raw = _extract_field(part, "Depends-On")
         priority_raw = _extract_field(part, "Priority")
         status_raw = _extract_field(part, "Status")
+        pr_raw = _extract_field(part, "PR")
 
         issues[issue_id] = {
             "manual": manual_raw.lower() == "true",
             "depends_on": _parse_depends_on(depends_raw),
             "priority": priority_raw.lower() if priority_raw else "p2",
             "status": status_raw.lower() if status_raw else "",
+            # PR ref (URL or number) — used by the ISSUE-052 merge-state probe.
+            "pr": pr_raw.strip(),
         }
 
     return issues
@@ -184,6 +201,116 @@ def detect_circular_deps(issues_meta: dict[str, dict]) -> list[str]:
             if result:
                 return result
     return []
+
+
+# ── Crash-recovery: already-merged PR awareness (ISSUE-052) ─────────
+
+
+def _gh_pr_merge_state(pr_ref, *, timeout=None, runner=None):
+    """Return the merge state of a PR: ``"merged"``, ``"open"``, or ``None``.
+
+    Uses ``gh pr view <ref> --json state,mergedAt``. A PR counts as merged when
+    ``state == "MERGED"`` OR a ``mergedAt`` timestamp is present (the GH issue is
+    then CLOSED). Degrades to ``None`` — never raises — on an empty ref, a
+    missing/unauthenticated ``gh``, a non-zero exit, a timeout, or unparseable
+    JSON, so callers fall back to a phase-only decision. Offline-safe: the probe
+    is timeout-guarded (see ``GH_MERGE_PROBE_TIMEOUT``).
+
+    ``runner`` (defaults to ``subprocess.run``) is injectable for testing.
+    """
+    if not pr_ref:
+        return None
+    runner = runner or subprocess.run
+    if timeout is None:
+        timeout = GH_MERGE_PROBE_TIMEOUT
+    try:
+        proc = runner(
+            ["gh", "pr", "view", pr_ref, "--json", "state,mergedAt"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(
+            f"Warning: gh merge-state probe failed for {pr_ref}: {exc}; "
+            "falling back to phase-only decision",
+            file=sys.stderr,
+        )
+        return None
+    if proc.returncode != 0:
+        print(
+            f"Warning: `gh pr view` exited {proc.returncode} for {pr_ref}: "
+            f"{proc.stderr.strip()}; falling back to phase-only decision",
+            file=sys.stderr,
+        )
+        return None
+    try:
+        data = json.loads(proc.stdout)
+    except (ValueError, TypeError) as exc:
+        print(
+            f"Warning: `gh pr view` returned unparseable JSON for {pr_ref}: {exc}; "
+            "falling back to phase-only decision",
+            file=sys.stderr,
+        )
+        return None
+    state = str(data.get("state") or "").upper()
+    if state == "MERGED" or data.get("mergedAt"):
+        return "merged"
+    return "open"
+
+
+def classify_ship_ready(ship_ready, issues_meta, *, merge_state_fn=None):
+    """Split reviewed/ship-ready issues into ``(finalize_ready, ship_ready)``.
+
+    An issue whose PR is already MERGED (a crash between the squash-merge and the
+    post-merge smoke checkpoint) goes to ``finalize_ready`` — only smoke +
+    registry remain, and no re-merge must be attempted. Un-merged or indeterminate
+    (``gh`` error / no PR ref) issues stay in ``ship_ready`` (phase-only fallback).
+    Order is preserved and the probe is cached per PR ref.
+    """
+    merge_state_fn = merge_state_fn or _gh_pr_merge_state
+    finalize_ready: list[str] = []
+    still_ship: list[str] = []
+    cache: dict[str, str | None] = {}
+    for issue_id in ship_ready:
+        pr_ref = issues_meta.get(issue_id, {}).get("pr", "")
+        if not pr_ref:
+            # No PR recorded — cannot probe; leave it on the normal ship path.
+            still_ship.append(issue_id)
+            continue
+        if pr_ref not in cache:
+            cache[pr_ref] = merge_state_fn(pr_ref)
+        if cache[pr_ref] == "merged":
+            finalize_ready.append(issue_id)
+        else:
+            still_ship.append(issue_id)
+    return finalize_ready, still_ship
+
+
+def ship_merge_decision(pr_ref, *, merge_state_fn=None):
+    """Idempotent ship-merge decision (ISSUE-052 crash-recovery safety net).
+
+    Returns ``{"action": "skip"|"merge", "reason": str}``. ``"skip"`` when the PR
+    is already merged — the ship executor then proceeds straight to smoke +
+    registry without a second merge. ``"merge"`` otherwise, INCLUDING the
+    ``gh``-indeterminate case (let the real ``gh pr merge`` surface any failure).
+    This guard is the safety net even if the queue's classification is stale.
+    """
+    merge_state_fn = merge_state_fn or _gh_pr_merge_state
+    state = merge_state_fn(pr_ref)
+    if state == "merged":
+        return {
+            "action": "skip",
+            "reason": (
+                f"PR {pr_ref} is already merged — skip merge, proceed to "
+                "smoke + registry finalization"
+            ),
+        }
+    return {
+        "action": "merge",
+        "reason": f"PR {pr_ref} not merged (state={state}) — perform the merge",
+    }
 
 
 # ── Queue computation ───────────────────────────────────────────────
@@ -257,9 +384,24 @@ def choose_action(
 ) -> dict:
     """Apply strict priority to choose ONE action.
 
-    Priority order: SHIP > REVIEW > IMPLEMENT > STUCK > DONE.
+    Priority order: FINALIZE > SHIP > REVIEW > IMPLEMENT > STUCK > DONE.
     Caps targets at max_parallel.
     """
+    # FINALIZE (ISSUE-052): reviewed issues whose PR is already merged are half-
+    # shipped — clear them first (smoke + registry only) so the pipeline reaches a
+    # clean state and no re-merge is ever attempted. `.get` keeps callers that
+    # build queues without this key (compute_queues) working unchanged.
+    if queues.get("finalize_ready"):
+        targets = queues["finalize_ready"][:max_parallel]
+        return {
+            "action": "FINALIZE",
+            "targets": targets,
+            "reason": (
+                f"{len(queues['finalize_ready'])} reviewed issue(s) whose PR is "
+                "already merged — finalize only (smoke + registry), no re-merge"
+            ),
+        }
+
     if queues["ship_ready"]:
         targets = queues["ship_ready"][:max_parallel]
         return {
@@ -422,6 +564,20 @@ def cmd_next_action(args: argparse.Namespace) -> int:
         return 1
 
     queues = compute_queues(sprint_rows, issues_meta)
+
+    # ISSUE-052 crash-recovery: for reviewed/ship-ready issues, probe the PR merge
+    # state before proposing SHIP. An already-merged PR (a crash between merge and
+    # the smoke checkpoint) is reclassified as FINALIZE (smoke + registry only).
+    # Guarded so an offline/hung/unauthenticated `gh` never blocks or crashes the
+    # frequently-run queue: probes are timeout-bounded and degrade to phase-only.
+    # `--no-check-merged` opts out entirely (offline/deterministic runs).
+    if not getattr(args, "no_check_merged", False) and queues["ship_ready"]:
+        finalize_ready, still_ship = classify_ship_ready(
+            queues["ship_ready"], issues_meta
+        )
+        queues["finalize_ready"] = finalize_ready
+        queues["ship_ready"] = still_ship
+
     result = choose_action(queues, args.max_parallel)
 
     print(json.dumps(result))
@@ -447,6 +603,19 @@ def cmd_validate(args: argparse.Namespace) -> int:
     result = validate_transitions(sprint_rows, args.action, targets)
     print(json.dumps(result))
     return 0 if result["valid"] else 1
+
+
+def cmd_ship_merge_decision(args: argparse.Namespace) -> int:
+    """Handler for 'ship-merge-decision' — idempotent merge guard (ISSUE-052).
+
+    Emits the JSON decision (``skip`` if the PR is already merged, else ``merge``)
+    that the ship executor consults before running ``gh pr merge``, so crash
+    recovery in the ship window never attempts a second merge. Always exits 0 —
+    a ``gh``-indeterminate probe yields ``merge`` and lets the real merge surface
+    any failure.
+    """
+    print(json.dumps(ship_merge_decision(args.pr)))
+    return 0
 
 
 # ── CLI entry point ─────────────────────────────────────────────────
@@ -480,6 +649,15 @@ def main(argv: list[str] | None = None) -> int:
         default=3,
         help="Maximum issues to process in parallel (default: 3)",
     )
+    na.add_argument(
+        "--no-check-merged",
+        action="store_true",
+        help=(
+            "Skip the ISSUE-052 `gh pr view` merge-state probe for reviewed "
+            "issues (offline / deterministic runs). Reviewed issues then always "
+            "propose SHIP (phase-only), never FINALIZE."
+        ),
+    )
 
     # validate subcommand
     va = subparsers.add_parser(
@@ -494,13 +672,24 @@ def main(argv: list[str] | None = None) -> int:
     va.add_argument(
         "--action",
         required=True,
-        choices=["SHIP", "REVIEW", "IMPLEMENT", "PIPELINE"],
+        choices=["SHIP", "REVIEW", "IMPLEMENT", "PIPELINE", "FINALIZE"],
         help="The action that was executed",
     )
     va.add_argument(
         "--targets",
         required=True,
         help="Comma-separated issue IDs (e.g. ISSUE-001,ISSUE-002)",
+    )
+
+    # ship-merge-decision subcommand (ISSUE-052 idempotent merge guard)
+    smd = subparsers.add_parser(
+        "ship-merge-decision",
+        help="Emit skip/merge for a PR so ship recovery never re-merges",
+    )
+    smd.add_argument(
+        "--pr",
+        required=True,
+        help="PR ref (number or URL) to probe for an already-merged state",
     )
 
     try:
@@ -516,6 +705,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_next_action(args)
     elif args.command == "validate":
         return cmd_validate(args)
+    elif args.command == "ship-merge-decision":
+        return cmd_ship_merge_decision(args)
 
     return 2
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -75,7 +75,24 @@ Steps:
    ```bash
    bash scripts/registry_edit.sh STATUS.md -- bash -c '<update command>'
    ```
-4) Merge via `gh pr merge` (merge/squash per repo rules) and delete branch.
+4) **Idempotent merge** (crash-recovery safe — ISSUE-052). A ship-phase interruption
+   (e.g. an API/spend limit) BETWEEN the merge and the smoke checkpoint can leave the
+   PR already **MERGED** while `sprint_state.md` still reads `reviewed`/`shipping`; in
+   that case `sprint_queue.py next-action` emits a **FINALIZE** action (smoke + registry
+   only), not SHIP. Whether invoked for a normal SHIP or a FINALIZE recovery, consult
+   the idempotent decision helper BEFORE merging so recovery never attempts a second
+   merge:
+   ```bash
+   python3 scripts/sprint_queue.py ship-merge-decision --pr <pr_number>
+   ```
+   - `{"action": "skip", ...}` (PR already merged) → do NOT run `gh pr merge`; proceed
+     straight to worktree cleanup, the smoke checkpoint, and registry finalization.
+   - `{"action": "merge", ...}` (un-merged, or `gh` indeterminate) → merge via
+     `gh pr merge` (merge/squash per repo rules) and delete the branch as usual.
+
+   The probe degrades gracefully (an offline/unauthenticated `gh` yields `merge`, so a
+   normal ship is never blocked); the merge checkpoint below still confirms the PR is
+   merged either way.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
 > Run: `bash scripts/checkpoint.sh --skill ship --phase merge --issue $ARGUMENTS`

--- a/skills/ship/SKILL.md.tmpl
+++ b/skills/ship/SKILL.md.tmpl
@@ -27,7 +27,24 @@ Steps:
    ```bash
    bash scripts/registry_edit.sh STATUS.md -- bash -c '<update command>'
    ```
-4) Merge via `gh pr merge` (merge/squash per repo rules) and delete branch.
+4) **Idempotent merge** (crash-recovery safe — ISSUE-052). A ship-phase interruption
+   (e.g. an API/spend limit) BETWEEN the merge and the smoke checkpoint can leave the
+   PR already **MERGED** while `sprint_state.md` still reads `reviewed`/`shipping`; in
+   that case `sprint_queue.py next-action` emits a **FINALIZE** action (smoke + registry
+   only), not SHIP. Whether invoked for a normal SHIP or a FINALIZE recovery, consult
+   the idempotent decision helper BEFORE merging so recovery never attempts a second
+   merge:
+   ```bash
+   python3 scripts/sprint_queue.py ship-merge-decision --pr <pr_number>
+   ```
+   - `{"action": "skip", ...}` (PR already merged) → do NOT run `gh pr merge`; proceed
+     straight to worktree cleanup, the smoke checkpoint, and registry finalization.
+   - `{"action": "merge", ...}` (un-merged, or `gh` indeterminate) → merge via
+     `gh pr merge` (merge/squash per repo rules) and delete the branch as usual.
+
+   The probe degrades gracefully (an offline/unauthenticated `gh` yields `merge`, so a
+   normal ship is never blocked); the merge checkpoint below still confirms the PR is
+   merged either way.
 
 > **CHECKPOINT — MANDATORY — NEVER SKIP**
 > Run: `{{CHECKPOINT_CMD}} --skill ship --phase merge --issue $ARGUMENTS`

--- a/skills/sprint/SKILL.md
+++ b/skills/sprint/SKILL.md
@@ -137,9 +137,9 @@ Never commit these files to feature branches.
 
       - If action = **DONE** → **Go to step 5.**
       - If action = **STUCK** → Log warning with the `reason`. Increment attempt counts for stuck issues in sprint_state.md. If attempts ≥ 3, escalate. Otherwise continue to next iteration.
-      - If action = **PIPELINE**, **SHIP**, or **REVIEW** → proceed to step 4d with the action and targets from the script output.
+      - If action = **PIPELINE**, **SHIP**, **REVIEW**, or **FINALIZE** → proceed to step 4d with the action and targets from the script output.
 
-      **IMPORTANT**: Do NOT manually compute queues or override the script's action choice. The script enforces strict priority ordering (SHIP > REVIEW > PIPELINE) to prevent phase skipping.
+      **IMPORTANT**: Do NOT manually compute queues or override the script's action choice. The script enforces strict priority ordering (FINALIZE > SHIP > REVIEW > PIPELINE) to prevent phase skipping. **FINALIZE** is a crash-recovery action (ISSUE-052): the queue detected a `reviewed` issue whose PR is already merged (a ship-phase interruption between the merge and the smoke checkpoint), so only smoke + registry remain — it must NOT be re-shipped/re-merged.
 
       > For reference, the script computes these queues internally:
       > - `ship_ready`    = issues where Phase = `reviewed`
@@ -151,7 +151,7 @@ Never commit these files to feature branches.
       ```
       You are the team-lead agent. Execute the {action} phase for these issues.
 
-      ## Phase: {PIPELINE | SHIP | REVIEW}
+      ## Phase: {PIPELINE | SHIP | REVIEW | FINALIZE}
 
       ## Target Issues
       {For each target: full issue spec from issues.md — ID, title, AC, all fields}
@@ -172,6 +172,7 @@ Never commit these files to feature branches.
       - **PIPELINE**: Full implement→review→ship for backlog issues. Each issue goes through all three phases in one invocation. No phase can be skipped.
       - **REVIEW**: Retry review for issues stuck in `implemented` status (recovery only).
       - **SHIP**: Retry ship for issues stuck in `reviewed` status (recovery only).
+      - **FINALIZE** (crash recovery, ISSUE-052): a `reviewed` issue whose PR is already merged. Route it to the team-lead **ship** executor — its merge step is idempotent (`python3 scripts/sprint_queue.py ship-merge-decision --pr <n>` returns `skip`), so it skips the already-done merge and completes only the post-merge smoke checkpoint + registry finalization. Never re-merge. Validate in step 4f with `--action FINALIZE` (expected end phase `shipped`).
 
    **e) After team-lead returns**:
       - Re-read `docs/sprint_state.md` to confirm phase transitions happened

--- a/skills/sprint/SKILL.md.tmpl
+++ b/skills/sprint/SKILL.md.tmpl
@@ -76,9 +76,9 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash(bash scripts/checkpoint
 
       - If action = **DONE** → **Go to step 5.**
       - If action = **STUCK** → Log warning with the `reason`. Increment attempt counts for stuck issues in sprint_state.md. If attempts ≥ 3, escalate. Otherwise continue to next iteration.
-      - If action = **PIPELINE**, **SHIP**, or **REVIEW** → proceed to step 4d with the action and targets from the script output.
+      - If action = **PIPELINE**, **SHIP**, **REVIEW**, or **FINALIZE** → proceed to step 4d with the action and targets from the script output.
 
-      **IMPORTANT**: Do NOT manually compute queues or override the script's action choice. The script enforces strict priority ordering (SHIP > REVIEW > PIPELINE) to prevent phase skipping.
+      **IMPORTANT**: Do NOT manually compute queues or override the script's action choice. The script enforces strict priority ordering (FINALIZE > SHIP > REVIEW > PIPELINE) to prevent phase skipping. **FINALIZE** is a crash-recovery action (ISSUE-052): the queue detected a `reviewed` issue whose PR is already merged (a ship-phase interruption between the merge and the smoke checkpoint), so only smoke + registry remain — it must NOT be re-shipped/re-merged.
 
       > For reference, the script computes these queues internally:
       > - `ship_ready`    = issues where Phase = `reviewed`
@@ -90,7 +90,7 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash(bash scripts/checkpoint
       ```
       You are the team-lead agent. Execute the {action} phase for these issues.
 
-      ## Phase: {PIPELINE | SHIP | REVIEW}
+      ## Phase: {PIPELINE | SHIP | REVIEW | FINALIZE}
 
       ## Target Issues
       {For each target: full issue spec from issues.md — ID, title, AC, all fields}
@@ -111,6 +111,7 @@ allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash(bash scripts/checkpoint
       - **PIPELINE**: Full implement→review→ship for backlog issues. Each issue goes through all three phases in one invocation. No phase can be skipped.
       - **REVIEW**: Retry review for issues stuck in `implemented` status (recovery only).
       - **SHIP**: Retry ship for issues stuck in `reviewed` status (recovery only).
+      - **FINALIZE** (crash recovery, ISSUE-052): a `reviewed` issue whose PR is already merged. Route it to the team-lead **ship** executor — its merge step is idempotent (`python3 scripts/sprint_queue.py ship-merge-decision --pr <n>` returns `skip`), so it skips the already-done merge and completes only the post-merge smoke checkpoint + registry finalization. Never re-merge. Validate in step 4f with `--action FINALIZE` (expected end phase `shipped`).
 
    **e) After team-lead returns**:
       - Re-read `docs/sprint_state.md` to confirm phase transitions happened

--- a/tests/test_sprint_queue.py
+++ b/tests/test_sprint_queue.py
@@ -1,6 +1,7 @@
 """Unit tests for scripts/sprint_queue.py."""
 
 import json
+import subprocess
 
 from scripts.sprint_queue import (
     _gh_pr_merge_state,
@@ -782,3 +783,31 @@ class TestCLIFinalize:
         out = json.loads(capsys.readouterr().out)
         assert exit_code == 0
         assert out["action"] == "merge"
+
+
+class TestGhPrMergeStateRobustness:
+    """Regression guards: the probe must NEVER raise (AC3 'never crashes')."""
+
+    def test_non_object_json_degrades_to_none(self, capsys):
+        # Valid JSON that is not an object — must not raise AttributeError.
+        for payload in ("null", "[]", "123", '"x"'):
+            r = _runner(stdout=payload)
+            assert _gh_pr_merge_state("123", runner=r) is None
+        assert "Warning" in capsys.readouterr().err
+
+    def test_timeout_is_passed_to_runner(self):
+        seen = {}
+
+        def _run(cmd, **kwargs):
+            seen.update(kwargs)
+            return _FakeProc(returncode=0, stdout=json.dumps({"state": "OPEN"}))
+
+        _gh_pr_merge_state("123", timeout=3.5, runner=_run)
+        assert seen.get("timeout") == 3.5
+
+    def test_timeout_expired_degrades_to_none(self, capsys):
+        def _run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout"))
+
+        assert _gh_pr_merge_state("123", runner=_run) is None
+        assert "Warning" in capsys.readouterr().err

--- a/tests/test_sprint_queue.py
+++ b/tests/test_sprint_queue.py
@@ -3,11 +3,14 @@
 import json
 
 from scripts.sprint_queue import (
+    _gh_pr_merge_state,
     choose_action,
+    classify_ship_ready,
     compute_queues,
     main,
     parse_issues_metadata,
     parse_sprint_table,
+    ship_merge_decision,
     validate_transitions,
 )
 
@@ -494,3 +497,288 @@ class TestCLI:
         assert exit_code == 1
         output = json.loads(captured.getvalue())
         assert output["action"] == "DONE"
+
+
+# ── ISSUE-052: crash-recovery — already-merged PR awareness ──────────
+
+
+class _FakeProc:
+    """Minimal stand-in for subprocess.CompletedProcess."""
+
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _runner(*, returncode=0, state=None, merged_at=None, stdout=None, stderr=""):
+    """Build a fake `runner` for _gh_pr_merge_state that records the argv."""
+    calls: list = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd)
+        payload = stdout
+        if payload is None:
+            payload = json.dumps({"state": state, "mergedAt": merged_at})
+        return _FakeProc(returncode=returncode, stdout=payload, stderr=stderr)
+
+    _run.calls = calls
+    return _run
+
+
+class TestGhPrMergeState:
+    def test_merged_by_state(self):
+        assert _gh_pr_merge_state("123", runner=_runner(state="MERGED")) == "merged"
+
+    def test_merged_by_mergedat_even_if_state_open(self):
+        # A PR can report a mergedAt timestamp; treat presence as merged.
+        r = _runner(state="OPEN", merged_at="2026-08-11T00:00:00Z")
+        assert _gh_pr_merge_state("123", runner=r) == "merged"
+
+    def test_open(self):
+        assert _gh_pr_merge_state("123", runner=_runner(state="OPEN")) == "open"
+
+    def test_empty_ref_returns_none_without_calling_gh(self):
+        r = _runner(state="MERGED")
+        assert _gh_pr_merge_state("", runner=r) is None
+        assert r.calls == []
+
+    def test_nonzero_exit_degrades_to_none_with_warning(self, capsys):
+        r = _runner(returncode=1, stderr="gh: not authenticated")
+        assert _gh_pr_merge_state("123", runner=r) is None
+        assert "Warning" in capsys.readouterr().err
+
+    def test_exception_degrades_to_none_with_warning(self, capsys):
+        def _boom(cmd, **kwargs):
+            raise OSError("gh executable not found")
+
+        assert _gh_pr_merge_state("123", runner=_boom) is None
+        assert "Warning" in capsys.readouterr().err
+
+    def test_unparseable_json_degrades_to_none(self):
+        r = _runner(stdout="not-json")
+        assert _gh_pr_merge_state("123", runner=r) is None
+
+    def test_argv_is_fixed_and_shell_free(self):
+        r = _runner(state="MERGED")
+        _gh_pr_merge_state("PR-REF", runner=r)
+        assert r.calls[0] == ["gh", "pr", "view", "PR-REF", "--json", "state,mergedAt"]
+
+
+class TestClassifyShipReady:
+    def test_merged_goes_to_finalize(self):
+        meta = {"ISSUE-001": {"pr": "https://x/y/pull/1"}}
+        fin, ship = classify_ship_ready(
+            ["ISSUE-001"], meta, merge_state_fn=lambda ref, **kw: "merged"
+        )
+        assert fin == ["ISSUE-001"]
+        assert ship == []
+
+    def test_open_stays_ship(self):
+        meta = {"ISSUE-001": {"pr": "pull/1"}}
+        fin, ship = classify_ship_ready(
+            ["ISSUE-001"], meta, merge_state_fn=lambda ref, **kw: "open"
+        )
+        assert fin == []
+        assert ship == ["ISSUE-001"]
+
+    def test_gh_error_stays_ship(self):
+        meta = {"ISSUE-001": {"pr": "pull/1"}}
+        fin, ship = classify_ship_ready(
+            ["ISSUE-001"], meta, merge_state_fn=lambda ref, **kw: None
+        )
+        assert fin == []
+        assert ship == ["ISSUE-001"]
+
+    def test_missing_pr_ref_stays_ship_without_probe(self):
+        meta = {"ISSUE-001": {"pr": ""}}
+        calls = []
+
+        def _fn(ref, **kw):
+            calls.append(ref)
+            return "merged"
+
+        fin, ship = classify_ship_ready(["ISSUE-001"], meta, merge_state_fn=_fn)
+        assert fin == []
+        assert ship == ["ISSUE-001"]
+        assert calls == []  # no PR ref → no gh probe
+
+    def test_order_preserved_and_probe_cached(self):
+        meta = {
+            "ISSUE-001": {"pr": "pull/1"},
+            "ISSUE-002": {"pr": "pull/1"},  # same ref → probed once
+            "ISSUE-003": {"pr": "pull/3"},
+        }
+        calls = []
+
+        def _fn(ref, **kw):
+            calls.append(ref)
+            return "merged" if ref == "pull/1" else "open"
+
+        fin, ship = classify_ship_ready(
+            ["ISSUE-001", "ISSUE-002", "ISSUE-003"], meta, merge_state_fn=_fn
+        )
+        assert fin == ["ISSUE-001", "ISSUE-002"]
+        assert ship == ["ISSUE-003"]
+        assert calls == ["pull/1", "pull/3"]  # pull/1 cached, not re-probed
+
+
+class TestChooseActionFinalize:
+    def test_finalize_takes_priority_over_ship(self):
+        queues = {
+            "finalize_ready": ["ISSUE-001"],
+            "ship_ready": ["ISSUE-002"],
+            "review_ready": ["ISSUE-003"],
+            "implement_ready": [],
+            "in_flight": [],
+        }
+        result = choose_action(queues, max_parallel=3)
+        assert result["action"] == "FINALIZE"
+        assert result["targets"] == ["ISSUE-001"]
+
+    def test_ship_when_no_finalize_key_present(self):
+        # Backward compat: compute_queues never emits finalize_ready.
+        queues = {
+            "ship_ready": ["ISSUE-001"],
+            "review_ready": [],
+            "implement_ready": [],
+            "in_flight": [],
+        }
+        result = choose_action(queues, max_parallel=3)
+        assert result["action"] == "SHIP"
+
+    def test_finalize_caps_at_max_parallel(self):
+        queues = {
+            "finalize_ready": ["ISSUE-001", "ISSUE-002", "ISSUE-003"],
+            "ship_ready": [],
+            "review_ready": [],
+            "implement_ready": [],
+            "in_flight": [],
+        }
+        result = choose_action(queues, max_parallel=2)
+        assert result["targets"] == ["ISSUE-001", "ISSUE-002"]
+
+
+class TestShipMergeDecision:
+    def test_skip_when_already_merged(self):
+        d = ship_merge_decision("pull/1", merge_state_fn=lambda ref, **kw: "merged")
+        assert d["action"] == "skip"
+        assert "pull/1" in d["reason"]
+
+    def test_merge_when_open(self):
+        d = ship_merge_decision("pull/1", merge_state_fn=lambda ref, **kw: "open")
+        assert d["action"] == "merge"
+
+    def test_merge_when_gh_indeterminate(self):
+        # gh error → default to merge; the real `gh pr merge` surfaces any failure.
+        d = ship_merge_decision("pull/1", merge_state_fn=lambda ref, **kw: None)
+        assert d["action"] == "merge"
+
+
+class TestParsePrField:
+    def test_parses_pr_field(self):
+        text = (
+            "### ISSUE-009: t\n- Priority: P1\n- Status: reviewed\n"
+            "- Depends-On: none\n- PR: https://github.com/x/y/pull/9\n\n"
+            "#### Acceptance Criteria (DoD)\n- [ ] a\n"
+        )
+        meta = parse_issues_metadata(text)
+        assert meta["ISSUE-009"]["pr"] == "https://github.com/x/y/pull/9"
+
+    def test_pr_defaults_to_empty(self):
+        text = _make_issue(num="001")
+        meta = parse_issues_metadata(text)
+        assert meta["ISSUE-001"]["pr"] == ""
+
+
+class TestValidateFinalize:
+    def test_valid_finalize_transition(self):
+        rows = [{"issue": "ISSUE-001", "status": "active", "attempts": "1", "last_error": "—", "phase": "shipped"}]
+        result = validate_transitions(rows, "FINALIZE", ["ISSUE-001"])
+        assert result["valid"] is True
+        assert result["transitioned"] == ["ISSUE-001"]
+
+    def test_finalize_stuck_if_not_shipped(self):
+        rows = [{"issue": "ISSUE-001", "status": "active", "attempts": "1", "last_error": "—", "phase": "reviewed"}]
+        result = validate_transitions(rows, "FINALIZE", ["ISSUE-001"])
+        assert result["valid"] is False
+        assert result["stuck"] == ["ISSUE-001"]
+
+
+class TestCLIFinalize:
+    def _sprint_and_issues(self, tmp_path, pr_line="- PR: https://github.com/x/y/pull/1"):
+        sprint = tmp_path / "sprint_state.md"
+        sprint.write_text(_make_sprint_state([
+            ("ISSUE-001", "active", "1", "—", "reviewed"),
+        ]))
+        issues = tmp_path / "issues.md"
+        issues.write_text(
+            "### ISSUE-001: t\n- Priority: P1\n- Status: reviewed\n"
+            f"- Depends-On: none\n{pr_line}\n\n"
+            "#### Acceptance Criteria (DoD)\n- [ ] a\n"
+        )
+        return sprint, issues
+
+    def _run_next_action(self, sprint, issues, capsys, extra=None):
+        argv = [
+            "next-action",
+            "--sprint-state", str(sprint),
+            "--issues", str(issues),
+            "--max-parallel", "2",
+        ]
+        if extra:
+            argv += extra
+        exit_code = main(argv)
+        out = json.loads(capsys.readouterr().out)
+        return exit_code, out
+
+    def test_finalize_when_pr_merged(self, tmp_path, capsys, monkeypatch):
+        import scripts.sprint_queue as q
+        monkeypatch.setattr(q, "_gh_pr_merge_state", lambda ref, **kw: "merged")
+        sprint, issues = self._sprint_and_issues(tmp_path)
+        _, out = self._run_next_action(sprint, issues, capsys)
+        assert out["action"] == "FINALIZE"
+        assert out["targets"] == ["ISSUE-001"]
+
+    def test_ship_when_pr_open(self, tmp_path, capsys, monkeypatch):
+        import scripts.sprint_queue as q
+        monkeypatch.setattr(q, "_gh_pr_merge_state", lambda ref, **kw: "open")
+        sprint, issues = self._sprint_and_issues(tmp_path)
+        _, out = self._run_next_action(sprint, issues, capsys)
+        assert out["action"] == "SHIP"
+        assert out["targets"] == ["ISSUE-001"]
+
+    def test_ship_when_gh_unavailable(self, tmp_path, capsys, monkeypatch):
+        import scripts.sprint_queue as q
+        monkeypatch.setattr(q, "_gh_pr_merge_state", lambda ref, **kw: None)
+        sprint, issues = self._sprint_and_issues(tmp_path)
+        exit_code, out = self._run_next_action(sprint, issues, capsys)
+        assert out["action"] == "SHIP"  # graceful phase-only fallback
+        assert exit_code == 0
+
+    def test_no_check_merged_flag_skips_probe(self, tmp_path, capsys, monkeypatch):
+        import scripts.sprint_queue as q
+
+        def _boom(ref, **kw):
+            raise AssertionError("gh probe must not run with --no-check-merged")
+
+        monkeypatch.setattr(q, "_gh_pr_merge_state", _boom)
+        sprint, issues = self._sprint_and_issues(tmp_path)
+        _, out = self._run_next_action(sprint, issues, capsys, extra=["--no-check-merged"])
+        assert out["action"] == "SHIP"
+
+    def test_ship_merge_decision_subcommand_skip(self, capsys, monkeypatch):
+        import scripts.sprint_queue as q
+        monkeypatch.setattr(q, "_gh_pr_merge_state", lambda ref, **kw: "merged")
+        exit_code = main(["ship-merge-decision", "--pr", "1"])
+        out = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        assert out["action"] == "skip"
+
+    def test_ship_merge_decision_subcommand_merge(self, capsys, monkeypatch):
+        import scripts.sprint_queue as q
+        monkeypatch.setattr(q, "_gh_pr_merge_state", lambda ref, **kw: "open")
+        exit_code = main(["ship-merge-decision", "--pr", "1"])
+        out = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        assert out["action"] == "merge"


### PR DESCRIPTION
Closes #82

## Problem
Twice last sprint a ship-phase team-lead died on an API limit BETWEEN the squash-merge
and the post-merge smoke checkpoint. The issue's `sprint_state` phase was still
`reviewed`/`shipping` while its PR was already merged and its GH issue CLOSED.
`sprint_queue.py next-action` reads only phase cells → re-proposed **SHIP** → the
orchestrator had to manually detect "already merged — only smoke + registry remain".
Risk of a double-merge attempt.

## What changed (end-to-end wiring)
- **New `FINALIZE` action.** For `reviewed`/ship-ready issues, `next-action` probes PR
  merge state (`gh pr view --json state,mergedAt`; MERGED **or** a `mergedAt` timestamp
  → merged) before proposing SHIP. Already-merged → **FINALIZE** (smoke + registry only),
  never SHIP, never a re-merge. `FINALIZE` is wired into `ACTION_END_PHASE` (ends at
  `shipped`) and the `validate` action choices.
- **Graceful degradation (AC3).** `_gh_pr_merge_state` returns `merged`/`open`/`None` and
  never raises — empty ref, missing/unauthenticated `gh`, non-zero exit, timeout, or
  unparseable JSON all degrade to a phase-only decision with a `Warning:` on stderr. The
  probe is timeout-bounded (`KIT_SPRINT_QUEUE_GH_TIMEOUT`, default 10s), cached per PR ref,
  and can be skipped entirely with `--no-check-merged`.
- **Idempotent merge guard (safety net).** `ship_merge_decision()` + a
  `ship-merge-decision --pr <ref>` subcommand emit `skip` when the PR is already merged
  (ship executor proceeds to smoke + registry) or `merge` otherwise. The ship SKILL merge
  step now consults it before `gh pr merge` (regenerated `skills/ship/SKILL.md`), so even a
  stale queue classification cannot cause a second merge.

## Design notes
- `choose_action` uses `queues.get("finalize_ready")` so existing callers that never build
  that key (`compute_queues`) are unaffected — no existing `next-action`/`validate` JSON
  consumer breaks. FINALIZE sits at the TOP of the priority order (a half-shipped issue is
  the most urgent to reconcile).
- The `gh` probe only runs for reviewed issues **with a recorded PR** — synthetic/offline
  runs and the whole existing test corpus never touch the network.

## AC
- [x] reviewed + PR merged → `next-action` proposes FINALIZE, not SHIP, never a re-merge.
- [x] reviewed + PR open → still proposes SHIP as today.
- [x] `gh` unavailable/unauthenticated → graceful phase-only fallback + logged warning, no crash.
- [x] Ship-executor idempotency: already-merged PR → merge step no-op (`ship_merge_decision` → skip).

## Tests
`tests/test_sprint_queue.py` extended (+31 cases): `_gh_pr_merge_state` (merged-by-state,
merged-by-mergedAt, open, empty-ref-no-call, non-zero-exit, exception, bad-JSON, fixed
shell-free argv), `classify_ship_ready` (finalize/ship/error/no-PR/order+cache),
`ship_merge_decision` (skip/merge/indeterminate), FINALIZE priority + max-parallel cap,
`PR` field parsing, `validate FINALIZE`, and CLI (FINALIZE / SHIP / graceful-fallback /
`--no-check-merged` / `ship-merge-decision`). Full suite: 1337 passed, 4 skipped.
Verified against real GitHub: merged PR #81 → `skip`; nonexistent PR → warning + `merge`.
