### PR TITLE
[ISSUE-053] Document the KIT_ALLOW_BROWSER_INSTALL + KIT_SPRINT_QUEUE_GH_TIMEOUT env knobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,24 @@ before the gate runs. Server-based gates (e2e-web, api) use
 `scripts/gate_server.sh` to start the app, poll a health endpoint, run
 the test command, and clean up the process group on exit.
 
+### Behaviour-control environment variables
+
+A few environment variables tune gate behaviour without editing code. All are
+optional — the defaults are safe for local and CI runs:
+
+- `KIT_CHECKPOINT_TEST_TIMEOUT` — seconds allowed for test-phase checkpoints
+  (`/implement` RED/test, `/ship` smoke) and the `verify_gates.py` unit gate.
+  Default `600`; invalid or non-positive values fall back to the default.
+- `KIT_SPRINT_QUEUE_GH_TIMEOUT` — default `10`; seconds for the sprint queue's
+  `gh pr view` merge-state probe (`scripts/sprint_queue.py`). On timeout the
+  probe degrades to a phase-only decision so an offline or hung `gh` never
+  blocks the frequently-run queue.
+- `KIT_ALLOW_BROWSER_INSTALL` — set to `1` to let the visual-diff and
+  computed-styles gates auto-install Playwright + Chromium (heavy network +
+  subprocess provisioning) when the browser is missing. Unset (the default) or
+  any other value keeps the gate side-effect-free: it skips with a "browser
+  unavailable" note instead of mutating the environment.
+
 ### Configuring gates via `docs/test_plan.md`
 
 `qa-designer` generates a `## Verify Gates Configuration` section in

--- a/docs/review_notes/ISSUE-053.md
+++ b/docs/review_notes/ISSUE-053.md
@@ -1,0 +1,27 @@
+# Review Notes — PR #85
+
+## Code Review
+_Source: reviewer-degraded_
+
+- **[Low] Drift guard only validates the README occurrence, not docs/troubleshooting.md**
+  Evidence: tests/test_env_knob_docs.py:77 combined.find("KIT_SPRINT_QUEUE_GH_TIMEOUT") returns the first occurrence (README, concatenated first at line 72), so the 240-char window at line 83 only ever covers the README mention. troubleshooting.md:30 ("defaults to `10` seconds") could drift independently and no test would catch it — test_troubleshooting_documents_both_new_env_knobs asserts only the knob NAME is present, not its value.
+  Fix: Iterate over all KIT_SPRINT_QUEUE_GH_TIMEOUT occurrences (or check the README and TROUBLESHOOTING windows separately) and assert the parsed default appears in each.
+
+- **[Low] Bare-substring `default in window` can mask drift for substring-numbers**
+  Evidence: tests/test_env_knob_docs.py:84 `default in window` is a substring test; if the code default ever changed to a value that is a substring of the stale documented number (e.g. a new `1` still found inside a stale `10`), the guard would pass despite real drift. Not exploitable at the current value (10), but brittle.
+  Fix: Match the documented value with a word boundary, e.g. re.search(rf"\b{re.escape(default)}\b", window).
+
+- **[Low] [info] Documented KIT_CHECKPOINT_TEST_TIMEOUT default 600 has no drift guard**
+  Evidence: README.md:653 documents default `600`, which matches verify_checkpoint.py:55 (_DEFAULT_TEST_TIMEOUT = 600) today, so there is no drift now. This third documented number is outside the test's coverage and could silently drift later. Out of ISSUE-053 AC scope (AC only covers the two new knobs).
+  Fix: Optional future hardening: extend the drift guard to also parse _DEFAULT_TEST_TIMEOUT out of verify_checkpoint.py. No action required for this issue.
+
+## Security Findings
+_Source: reviewer-degraded_
+
+_No findings._
+
+## Over-Engineering
+
+- **[Low] [shrink] Two near-identical doc-presence tests could collapse into one loop**
+  Evidence: tests/test_env_knob_docs.py:51-66 test_readme_documents_both_new_env_knobs and test_troubleshooting_documents_both_new_env_knobs differ only by the target file. Net removable ~7 lines.
+  Fix: Optional: loop over ((README, "README.md"), (TROUBLESHOOTING, "docs/troubleshooting.md")). Judgment call, not a clear win — splitting preserves independent pass/fail and per-file failure messages. Otherwise lean; ship.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,6 +19,16 @@ Common issues and solutions when using the claude-dev-kit pipeline.
 - **Cause**: Running verify_checkpoint.py from a worktree where issues.md doesn't exist
 - **Solution**: The script should auto-detect the repo root. Ensure `scripts/worktree.sh` exists or that you're in a valid git repository.
 
+### Problem: Visual-diff / computed-styles gate reports "browser unavailable"
+- **Symptom**: The visual-diff or computed-styles gate is skipped with a "browser unavailable" note on stderr
+- **Cause**: Playwright/Chromium is not installed, and by default the gate will not install it — a review/CI gate must not mutate its environment or hit the network as a silent side effect
+- **Solution**: Set `KIT_ALLOW_BROWSER_INSTALL=1` to auto-install Playwright + Chromium before the gate runs. If you leave it unset the skip is intentional, not a failure.
+
+### Problem: Sprint queue PR merge-state probe is slow or hangs
+- **Symptom**: The sprint queue stalls while checking a PR's merge state against an offline or hung `gh`
+- **Cause**: The `gh pr view` merge-state probe in `scripts/sprint_queue.py` is timeout-bounded so a stuck `gh` never blocks the frequently-run queue
+- **Solution**: `KIT_SPRINT_QUEUE_GH_TIMEOUT` defaults to `10` seconds; on timeout the probe degrades to a phase-only decision. Override the bound by exporting `KIT_SPRINT_QUEUE_GH_TIMEOUT=<seconds>`.
+
 ## GitHub Authentication
 
 ### Problem: `gh auth status` fails

--- a/tests/test_env_knob_docs.py
+++ b/tests/test_env_knob_docs.py
@@ -1,0 +1,88 @@
+"""Lightweight docs-consistency assertion for the two operator env knobs (ISSUE-053).
+
+Two env vars change runtime behavior and must be discoverable by operators, so
+this small test module makes a docs-consistency assertion over the user-facing
+docs: it verifies both knob names are documented and that the documented default
+has not drifted from the code. It extends the existing docs-test coverage rather
+than exercising runtime behavior. The two knobs are:
+- KIT_ALLOW_BROWSER_INSTALL — opt-in for the Playwright browser install step
+- KIT_SPRINT_QUEUE_GH_TIMEOUT — seconds for the sprint-queue `gh pr view`
+  merge-state probe (scripts/sprint_queue.py)
+
+The three tests assert:
+- README.md documents both new knob names (test_readme_documents_both_new_env_knobs).
+- docs/troubleshooting.md documents both new knob names
+  (test_troubleshooting_documents_both_new_env_knobs).
+- a drift guard that ties the documented KIT_SPRINT_QUEUE_GH_TIMEOUT default to
+  the code constant (test_sprint_queue_timeout_default_matches_docs): the default
+  is parsed out of sprint_queue.py at runtime (never hardcoded here), so a future
+  default change forces the user-facing docs to be updated in lockstep
+  (canonical-env-numbers lesson).
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+TROUBLESHOOTING = ROOT / "docs" / "troubleshooting.md"
+SPRINT_QUEUE = ROOT / "scripts" / "sprint_queue.py"
+
+KNOBS = ("KIT_ALLOW_BROWSER_INSTALL", "KIT_SPRINT_QUEUE_GH_TIMEOUT")
+
+# Parses the numeric default out of the exact expression in sprint_queue.py:
+#     os.environ.get("KIT_SPRINT_QUEUE_GH_TIMEOUT", "10")
+_DEFAULT_RE = re.compile(
+    r'os\.environ\.get\(\s*["\']KIT_SPRINT_QUEUE_GH_TIMEOUT["\']\s*,\s*["\'](\d+)["\']\s*\)'
+)
+
+
+def _parsed_gh_timeout_default() -> str:
+    """Return the KIT_SPRINT_QUEUE_GH_TIMEOUT default string parsed from code."""
+    m = _DEFAULT_RE.search(SPRINT_QUEUE.read_text(encoding="utf-8"))
+    assert m, (
+        "could not parse the KIT_SPRINT_QUEUE_GH_TIMEOUT default out of "
+        f"{SPRINT_QUEUE.name}; the os.environ.get(...) shape changed — update "
+        "the regex (and this drift guard) alongside it"
+    )
+    return m.group(1)
+
+
+def test_readme_documents_both_new_env_knobs():
+    readme = README.read_text(encoding="utf-8")
+    missing = [knob for knob in KNOBS if knob not in readme]
+    assert not missing, (
+        f"README.md does not document env knob(s): {missing}; "
+        "operators cannot discover them"
+    )
+
+
+def test_troubleshooting_documents_both_new_env_knobs():
+    text = TROUBLESHOOTING.read_text(encoding="utf-8")
+    missing = [knob for knob in KNOBS if knob not in text]
+    assert not missing, (
+        f"docs/troubleshooting.md does not document env knob(s): {missing}; "
+        "operators cannot discover them"
+    )
+
+
+def test_sprint_queue_timeout_default_matches_docs():
+    default = _parsed_gh_timeout_default()
+    combined = (
+        README.read_text(encoding="utf-8")
+        + "\n"
+        + TROUBLESHOOTING.read_text(encoding="utf-8")
+    )
+
+    idx = combined.find("KIT_SPRINT_QUEUE_GH_TIMEOUT")
+    assert idx != -1, (
+        "KIT_SPRINT_QUEUE_GH_TIMEOUT is not documented in README.md or "
+        "docs/troubleshooting.md, so its default cannot be verified"
+    )
+
+    window = combined[idx:idx + 240]
+    assert default in window, (
+        f"documented KIT_SPRINT_QUEUE_GH_TIMEOUT default should be {default!r} "
+        f"(parsed from {SPRINT_QUEUE.name}) but that value does not appear near "
+        "the knob's mention in the docs — the docs drifted from the code default"
+    )


### PR DESCRIPTION
Closes #84

Documents the operator-facing environment knobs that change gate/queue runtime behaviour so they are discoverable outside the source.

## Knobs documented
- `KIT_ALLOW_BROWSER_INSTALL` — opt-in (`=1`) that lets the visual-diff / computed-styles gates auto-install Playwright + Chromium. Unset/default keeps the gate side-effect-free: it skips with a "browser unavailable" note rather than mutating the environment or hitting the network (ISSUE-049).
- `KIT_SPRINT_QUEUE_GH_TIMEOUT` — seconds for the sprint queue's `gh pr view` merge-state probe (`scripts/sprint_queue.py`), default `10`; on timeout the probe degrades to a phase-only decision so an offline/hung `gh` never blocks the frequently-run queue (ISSUE-052).
- Also documents `KIT_CHECKPOINT_TEST_TIMEOUT` (default `600`) for consistency, since all three are now in one place (ISSUE-046/047).

## Changes
- `README.md` — new `### Behaviour-control environment variables` subsection in the Verify Gates area listing all three knobs (name, default, effect).
- `docs/troubleshooting.md` — two new `### Problem:` entries under `## Checkpoint Failures` for the browser-install skip and the merge-state probe timeout.
- `tests/test_env_knob_docs.py` — docs-consistency test: both new knobs appear in README + troubleshooting, plus a drift guard that parses the `KIT_SPRINT_QUEUE_GH_TIMEOUT` default out of `scripts/sprint_queue.py` and asserts it appears next to the knob's documented mention (canonical-env-numbers lesson — never hardcode the number in the test).

Docs-only: no knob behaviour or defaults changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)